### PR TITLE
fix: version matching regex

### DIFF
--- a/src/roll-chromium.ts
+++ b/src/roll-chromium.ts
@@ -189,7 +189,7 @@ export async function rollChromium4(
       d(`found existing PR: #${pr.number}, updating`);
       await updateDepsFile4(pr.head.ref, chromiumVersion);
       const m = /^Original-Chromium-Version: (\S+)/m.exec(pr.body);
-      const previousChromiumVersion = m ? m[1] : /chromium\/src\/+\/([^.]+?)\.\./.exec(pr.body)[1];
+      const previousChromiumVersion = m ? m[1] : /chromium\/src\/\+\/(.+?)\.\./.exec(pr.body)[1];
       await github.pulls.update({
         owner: 'electron',
         repo: 'electron',


### PR DESCRIPTION
causes error:

```
  roller:handleChromiumCheck() Error rolling 6-0-x to 76.0.3796.1 TypeError: Cannot read property '1' of null
    at Object.rollChromium4 (/app/lib/roll-chromium.js:164:102)
    at process._tickCallback (internal/process/next_tick.js:68:7) +1s
```