### PR TITLE
chore: update deprecated call to authenticate

### DIFF
--- a/src/utils/octokit.ts
+++ b/src/utils/octokit.ts
@@ -8,11 +8,8 @@ let octokit: GitHub;
  * @returns {Promise<GitHub>}
  */
 export async function getOctokit(): Promise<GitHub> {
-  octokit = octokit || new GitHub();
-
-  octokit.authenticate({
-    type: 'token',
-    token: process.env.GITHUB_TOKEN,
+  octokit = octokit || new GitHub({
+    auth: process.env.GITHUB_TOKEN,
   });
 
   return octokit;


### PR DESCRIPTION
Noticed this warning when running stuff locally.

```
[@octokit/rest] octokit.authenticate() is deprecated. Use "auth" constructor option instead.'
```

See code: https://github.com/octokit/rest.js/blob/7601bd78c449bf33c2058ce94e2ef3e7d3106c9c/plugins/authentication-deprecated/authenticate.js#L8-L10

Updated the call to reflect the Octokit docs: https://octokit.github.io/rest.js/#authentication