### PR TITLE
chore: add jest coverage folder to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .gitignore
 lib
 node_modules
+coverage


### PR DESCRIPTION
Our `npm test` command currently auto-generates a `/coverage/` report from Jest.