### PR TITLE
feat: stop bumping PRs after 10 days [RFC]

### DIFF
--- a/src/roll-chromium.ts
+++ b/src/roll-chromium.ts
@@ -189,7 +189,7 @@ export async function rollChromium4(
     // Update the existing PR (s?)
     for (const pr of myPrs) {
       d(`found existing PR: #${pr.number}, updating`);
-      const daysOld = (+new Date() - +new Date(pr.created_at)) / 1000 / 60 / 60 / 24
+      const daysOld = (+new Date() - +new Date(pr.created_at)) / 1000 / 60 / 60 / 24;
       if (daysOld > 10) {
         d(`PR is ${daysOld} days old, waiting for maintainers to catch up`);
         continue;

--- a/src/roll-chromium.ts
+++ b/src/roll-chromium.ts
@@ -189,6 +189,11 @@ export async function rollChromium4(
     // Update the existing PR (s?)
     for (const pr of myPrs) {
       d(`found existing PR: #${pr.number}, updating`);
+      const daysOld = (new Date() - new Date(pr.created_at)) / 1000 / 60 / 60 / 24
+      if (daysOld > 10) {
+        d(`PR is ${daysOld} days old, waiting for maintainers to catch up`);
+        continue;
+      }
       const previousVersion = await updateDepsFile4(pr.head.ref, chromiumVersion);
       if (previousVersion === chromiumVersion) {
         d(`version unchanged, skipping PR body update`);

--- a/src/roll-chromium.ts
+++ b/src/roll-chromium.ts
@@ -189,7 +189,7 @@ export async function rollChromium4(
     // Update the existing PR (s?)
     for (const pr of myPrs) {
       d(`found existing PR: #${pr.number}, updating`);
-      const daysOld = (new Date() - new Date(pr.created_at)) / 1000 / 60 / 60 / 24
+      const daysOld = (+new Date() - +new Date(pr.created_at)) / 1000 / 60 / 60 / 24
       if (daysOld > 10) {
         d(`PR is ${daysOld} days old, waiting for maintainers to catch up`);
         continue;


### PR DESCRIPTION
The thought here is that if a PR is taking more than 10 days to land we should probably stop adding new breakage to the PR and let maintainers fix what's there.