### PR TITLE
fix: correct constant in roll Chromium PR request

### DIFF
--- a/src/roll-chromium.ts
+++ b/src/roll-chromium.ts
@@ -230,7 +230,7 @@ export async function rollChromium4(
       owner: 'electron',
       repo: 'electron',
       base: electronBranch.name,
-      head: `${REPO_NAME}:${branchName}`,
+      head: `${REPO_OWNER}:${branchName}`,
       ...prText(previousChromiumVersion, chromiumVersion, electronBranch.name),
     });
     d(`new PR: ${newPr.data.html_url}`);


### PR DESCRIPTION
There should be no effect because `REPO_OWNER` and `REPO_NAME` are the same for `electron/electron`, but we should be using `REPO_OWNER` in the business logic here.

[See GitHub docs for the `head` attribute](https://developer.github.com/v3/pulls/#input):
>The name of the branch where your changes are implemented. For cross-repository pull requests in the same network, namespace head with a user like this: `username:branch`.