### PR TITLE
feat: use more descriptive link to view changes

### DIFF
--- a/src/roll-chromium.ts
+++ b/src/roll-chromium.ts
@@ -153,7 +153,8 @@ function prText(previousChromiumVersion: string, chromiumVersion: string, branch
   const isLKGR = !chromiumVersion.includes('.');
   const shortVersion = isLKGR ? chromiumVersion.substr(11) : chromiumVersion;
   const shortPreviousVersion = isLKGR ? previousChromiumVersion.substr(11) : previousChromiumVersion;
-  const diffLink = `https://chromium.googlesource.com/chromium/src/+/${previousChromiumVersion}..${chromiumVersion}`;
+  const diffLink = `https://chromium.googlesource.com/chromium/src/+log/` +
+                   `${previousChromiumVersion}..${chromiumVersion}?n=10000&pretty=fuller`;
   return {
     title: `chore: bump chromium to ${shortVersion} (${branchName})`,
     body: `Updating Chromium to ${shortVersion}${isLKGR ? ' (lkgr)' : ''}.


### PR DESCRIPTION
This PR updates the link `See [all changes in See all changes in xx.x.xxxx.xx..yy.y.yyyy.yy]` to use the more descriptive format that shows logs as well as the file changes, eg: 
https://chromium.googlesource.com/chromium/src/+log/76.0.3809.74..76.0.3809.77?n=10000&pretty=fuller
instead of 
https://chromium.googlesource.com/chromium/src/+/76.0.3809.74..76.0.3809.77
