### PR TITLE
feat: pause updates on label not time

### DIFF
--- a/src/utils/roll.ts
+++ b/src/utils/roll.ts
@@ -30,12 +30,14 @@ export async function roll({ rollTarget, electronBranch, targetVersion }: RollPa
     .filter((pr) => pr.user.login === PR_USER && pr.title.includes(rollTarget.name));
 
   if (myPrs.length) {
-    // Update the existing PR (s?)
+    // Update existing PR(s)
     for (const pr of myPrs) {
       d(`found existing PR: #${pr.number}, attempting DEPS update`);
-      const daysOld = (+new Date() - +new Date(pr.created_at)) / 1000 / 60 / 60 / 24;
-      if (daysOld > 10) {
-        d(`PR is ${daysOld} days old, waiting for maintainers to catch up`);
+
+      // Check to see if automatic DEPS roll has been temporarily disabled
+      const hasPauseLabel = pr.labels.some((label) => label.name === 'roller/pause');
+      if (hasPauseLabel) {
+        d(`Automatic updates have been paused for this PR, skipping DEPS roll.`);
         continue;
       }
 

--- a/tests/utils/pr-text-spec.ts
+++ b/tests/utils/pr-text-spec.ts
@@ -87,7 +87,7 @@ describe('getPRText()', () => {
   it('throws if invalid roll target passed in', () => {
     const target: RollTarget = {
       name: '💩',
-      key: '🔑'
+      depsKey: '🔑'
     };
     const details = {
       newVersion: 'v10.0.0',

--- a/tests/utils/roll-spec.ts
+++ b/tests/utils/roll-spec.ts
@@ -54,6 +54,10 @@ describe('roll()', () => {
           ref: 'asd'
         },
         body: 'Original-Version: v4.0.0',
+        labels: [
+          { name: 'hello' },
+          { name: 'goodbye' }
+        ],
         created_at: (new Date()).toISOString()
       }]
     );
@@ -85,6 +89,10 @@ describe('roll()', () => {
           ref: 'asd'
         },
         body: 'Original-Version: v4.0.0',
+        labels: [
+          { name: 'hello' },
+          { name: 'goodbye' }
+        ],
         created_at: (new Date()).toISOString()
       }]
     );
@@ -127,7 +135,7 @@ describe('roll()', () => {
     }));
   });
 
-  it('skips PR if existing one is stale', async () => {
+  it('skips PR if existing one has been paused', async () => {
     this.mockOctokit.paginate.mockReturnValue(
       [{
         user: {
@@ -139,6 +147,9 @@ describe('roll()', () => {
           ref: 'asd'
         },
         body: 'Original-Version: v4.0.0',
+        labels: [
+          { name: 'roller/pause' }
+        ],
         created_at: (new Date('December 17, 1995 03:24:00')).toISOString()
       }]
     );


### PR DESCRIPTION
Update `roller` to halt updates in a label rather than time-delimited fashion

Adding the `pause-roll` label to a PR will prevent DEPS updates.

cc @electron/wg-upgrades 