### PR TITLE
chore: update npm scripts and remove start

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "lint": "tslint --project '.'",
     "prestart": "tsc",
     "prepare": "tsc",
-    "start": "DEBUG=roller* node lib/index.js",
+    "roll-chromium": "DEBUG=roller* node lib/chromium-cron.js",
+    "roll-node": "DEBUG=roller* node lib/node-cron.js",
     "test": "jest --config=jest.json --coverage"
   },
   "repository": {


### PR DESCRIPTION
Updates npm scripts to make local runs more accurate and simpler. Also remove unnecessary `npm start`.

cc @nornagon @MarshallOfSound 