### PR TITLE
chore: improve logging and add start

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "prepare": "tsc",
     "roll-chromium": "DEBUG=roller* node lib/chromium-cron.js",
     "roll-node": "DEBUG=roller* node lib/node-cron.js",
+    "start": "echo \"Starting roller bot.\" && exit 0",
     "test": "jest --config=jest.json --coverage"
   },
   "repository": {

--- a/tests/handlers-spec.ts
+++ b/tests/handlers-spec.ts
@@ -111,7 +111,7 @@ describe('handleChromiumCheck()', () => {
         await handleChromiumCheck();
       } catch (e) {
         expect(roll).not.toBeCalled();
-        expect(e.message).toMatch('One or more upgrade checks failed; see the logs for details');
+        expect(e.message).toMatch('One or more upgrade checks failed - see logs for more details');
       }
     });
   });
@@ -193,7 +193,7 @@ describe('handleChromiumCheck()', () => {
     (roll as jest.Mock).mockImplementationOnce(() => {
       throw new Error('');
     })
-    await expect(handleChromiumCheck()).rejects.toThrowError(`One or more upgrade checks failed; see the logs for details`);
+    await expect(handleChromiumCheck()).rejects.toThrowError(`One or more upgrade checks failed - see logs for more details`);
     expect(roll).toHaveBeenCalled();
   })
 });
@@ -287,7 +287,7 @@ describe('handleNodeCheck()', () => {
     (roll as jest.Mock).mockImplementationOnce(() => {
       throw new Error('');
     })
-    await expect(handleNodeCheck()).rejects.toThrowError(`Upgrade check failed; see the logs for details`);
+    await expect(handleNodeCheck()).rejects.toThrowError(`Upgrade check failed - see logs for more details`);
     expect(roll).toHaveBeenCalled();
   });
 })


### PR DESCRIPTION
Heroku does seem to expect a `start` script even if it's a no-op, so i've gone ahead and added that back. Also cleans up and adds some more verbose logging.

cc @MarshallOfSound @nornagon 