### PR TITLE
chore: add upgrades as CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Fall back to authors for all PR review
+* @electron/wg-upgrades


### PR DESCRIPTION
Set @electron/wg-upgrades as a CODEOWNER for roller.

cc @electron/wg-upgrades 