### PR TITLE
fix: properly check for supported branches

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -9,6 +9,8 @@ export const REPOS = {
   },
 };
 
+export const NUM_SUPPORTED_VERSIONS = 4;
+
 export const ROLL_TARGETS = {
   node: {
     name: 'node',

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -14,12 +14,12 @@ export function getSupportedBranches(branches): string[] {
     return releasePattern.test(branch.name);
   }).map((b) => b.name);
 
-  const filtered = {};
+  const filtered: Record<string, string> = {};
   releaseBranches.sort().forEach((branch: string) => {
     return filtered[branch.split('-')[0]] = branch;
   });
 
-  const values = Object.keys(filtered).map((key) => filtered[key]);
+  const values = Object.values(filtered);
   return values.sort().slice(-NUM_SUPPORTED_VERSIONS);
 }
 

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -8,7 +8,7 @@ import { getOctokit } from './utils/octokit';
 import { roll } from './utils/roll';
 
 // Get array of currently supported branches
-export function getSupportedBranches(branches): string[] {
+export function getSupportedBranches(branches: {name: string}[]): string[] {
   const releaseBranches = branches.filter((branch) => {
     const releasePattern = /^[0-9]+-([0-9]+-x|x-y)$/;
     return releasePattern.test(branch.name);

--- a/src/utils/update-deps.ts
+++ b/src/utils/update-deps.ts
@@ -7,6 +7,7 @@ export interface UpdateDepsParams {
   branch: string;
   targetVersion: string;
 }
+
 export async function updateDepsFile({ depName, depKey, branch, targetVersion }: UpdateDepsParams) {
   const github = await getOctokit();
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,9 +3,6 @@
 		"module": "commonjs",
 		"target": "es2018",
 		"outDir": "lib",
-		"lib": [
-			"es6"
-		],
 		"sourceMap": true,
 		"rootDir": "src",
     "experimentalDecorators": true,


### PR DESCRIPTION
Ensures that only applicable supported branches are rolled against. At present, for example, only `8-x-y`, `7-1-x`, `6-1-x`, and `5-0-x` would need to be rolled against. This also allows us to remove code that checks against versions being rolled against that are <= v3.

Also changes the octokit call in `handleNodeCheck` from `listBranches` to `getBranch` since we're only rolling `master` for now.

cc @nornagon @jkleinsc 