### PR TITLE
fix: delete orphan branches before rolling

### DIFF
--- a/tests/utils/roll-spec.ts
+++ b/tests/utils/roll-spec.ts
@@ -32,7 +32,9 @@ describe('roll()', () => {
         create: jest.fn().mockReturnValue({data: {html_url: 'https://google.com'}})
       },
       git: {
-        createRef: jest.fn()
+        createRef: jest.fn(),
+        getRef: jest.fn().mockReturnValue({status: 404}),
+        deleteRef: jest.fn()
       }
     };
     (getOctokit as jest.Mock).mockReturnValue(this.mockOctokit);


### PR DESCRIPTION
Closes https://github.com/electron/roller/issues/41.

Checks if a valid ref already exists (but no PR is open, meaning that it's an orphan branch) and deletes the ref before attempting to open a new roller PR.

cc @erickzhao @nornagon 