### PR TITLE
fix: httperror on ref not found

### DIFF
--- a/src/utils/roll.ts
+++ b/src/utils/roll.ts
@@ -88,10 +88,14 @@ export async function roll({
     const ref = `refs/heads/${branchName}`;
 
     d(`Checking that no orphan ref exists from a previous roll`);
-    const maybeOldRef = await github.git.getRef({ ...REPOS.electron, ref });
-    if (maybeOldRef.status !== 404) {
-      d(`Found orphan ref ${ref} with no open PR - deleting`);
-      await github.git.deleteRef({ ...REPOS.electron, ref });
+    try {
+      const maybeOldRef = await github.git.getRef({ ...REPOS.electron, ref });
+      if (maybeOldRef.status === 200) {
+        d(`Found orphan ref ${ref} with no open PR - deleting`);
+        await github.git.deleteRef({ ...REPOS.electron, ref });
+      }
+    } catch (error) {
+      d(`No orphan ref exists at ${ref} - proceeding`);
     }
 
     d(`Creating ref=${ref} at sha=${sha}`);


### PR DESCRIPTION
Fixes a bug in the GitHub API whereby nonexistent refs are _supposed_ to return a status 404, but instead throw an HTTP error. 

Prior art taken from the approach of a GitHub employee who worked around this issue the same way in [this action](https://github.com/jeffrafter/setup-action/blob/0d86e4ae9bfea76f2cb733208310277fb6e29b8e/setup.ts#L26-L39)

cc @nornagon 