### PR TITLE
refactor: roll on Chromium master not lkgr

### DIFF
--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -3,7 +3,7 @@ import * as semver from 'semver';
 
 import { NUM_SUPPORTED_VERSIONS, REPOS, ROLL_TARGETS } from './constants';
 import { compareChromiumVersions } from './utils/compare-chromium-versions';
-import { getChromiumLkgr, getChromiumTags } from './utils/get-chromium-tags';
+import { getChromiumMaster, getChromiumTags } from './utils/get-chromium-tags';
 import { getOctokit } from './utils/octokit';
 import { roll } from './utils/roll';
 
@@ -108,17 +108,17 @@ export async function handleChromiumCheck(): Promise<void> {
       const deps = Buffer.from(depsData.content, 'base64').toString('utf8');
       const hashRegex = new RegExp(`${ROLL_TARGETS.chromium.depsKey}':\n +'(.+?)',`, 'm');
       const [, chromiumHash] = hashRegex.exec(deps);
-      const lkgr = await getChromiumLkgr();
-      if (chromiumHash !== lkgr.commit) {
-        d(`Updating master from ${chromiumHash} to ${lkgr.commit}`);
+      const master = await getChromiumMaster();
+      if (chromiumHash !== master.commit) {
+        d(`Updating master from ${chromiumHash} to ${master.commit}`);
         try {
           await roll({
             rollTarget: ROLL_TARGETS.chromium,
             electronBranch: masterBranch,
-            targetVersion: lkgr.commit,
+            targetVersion: master.commit,
           });
         } catch (e) {
-          d(`Error rolling ${masterBranch.name} to ${lkgr.commit}`, e);
+          d(`Error rolling ${masterBranch.name} to ${master.commit}`, e);
           thisIsFine = false;
         }
       }

--- a/src/utils/get-chromium-tags.ts
+++ b/src/utils/get-chromium-tags.ts
@@ -52,6 +52,6 @@ export function getChromiumCommits(
   );
 }
 
-export function getChromiumLkgr(): Promise<any> {
-  return getJSON(`https://chromium.googlesource.com/chromium/src/+/refs/heads/lkgr?format=JSON`);
+export function getChromiumMaster(): Promise<any> {
+  return getJSON(`https://chromium.googlesource.com/chromium/src/+/refs/heads/master?format=JSON`);
 }

--- a/src/utils/pr-text.ts
+++ b/src/utils/pr-text.ts
@@ -20,15 +20,15 @@ export function getPRText(rollTarget: RollTarget, details: PRTextDetails) {
 function getChromiumPRText(details: PRTextDetails) {
   const { newVersion, previousVersion, branchName } = details;
 
-  const isLKGR = !newVersion.includes('.');
-  const shortVersion = isLKGR ? newVersion.substr(11) : newVersion;
-  const shortPreviousVersion = isLKGR ? previousVersion.substr(11) : previousVersion;
+  const isMaster = !newVersion.includes('.');
+  const shortVersion = isMaster ? newVersion.substr(11) : newVersion;
+  const shortPreviousVersion = isMaster ? previousVersion.substr(11) : previousVersion;
   const diffLink =
     `https://chromium.googlesource.com/chromium/src/+log/` +
     `${previousVersion}..${newVersion}?n=10000&pretty=fuller`;
   return {
     title: `chore: bump ${ROLL_TARGETS.chromium.name} to ${shortVersion} (${branchName})`,
-    body: `Updating Chromium to ${shortVersion}${isLKGR ? ' (lkgr)' : ''}.
+    body: `Updating Chromium to ${shortVersion}${isMaster ? ' (master)' : ''}.
 
 See [all changes in ${shortPreviousVersion}..${shortVersion}](${diffLink})
 
@@ -36,7 +36,7 @@ See [all changes in ${shortPreviousVersion}..${shortVersion}](${diffLink})
 Original-Version: ${previousVersion}
 -->
 
-Notes: ${isLKGR ? 'no-notes' : `Updated Chromium to ${newVersion}.`}`,
+Notes: ${isMaster ? 'no-notes' : `Updated Chromium to ${newVersion}.`}`,
   };
 }
 

--- a/tests/handlers-spec.ts
+++ b/tests/handlers-spec.ts
@@ -1,7 +1,7 @@
 
 import { REPOS, ROLL_TARGETS } from '../src/constants';
 import { handleChromiumCheck, handleNodeCheck, getSupportedBranches } from '../src/handlers';
-import { getChromiumLkgr, getChromiumTags } from '../src/utils/get-chromium-tags';
+import { getChromiumMaster, getChromiumTags } from '../src/utils/get-chromium-tags';
 import { getOctokit } from '../src/utils/octokit';
 import { roll } from '../src/utils/roll';
 
@@ -164,12 +164,12 @@ describe('handleChromiumCheck()', () => {
         },
       });
 
-      (getChromiumLkgr as jest.Mock).mockReturnValue({
+      (getChromiumMaster as jest.Mock).mockReturnValue({
         commit: 'new-sha'
       });
     });
 
-    it('updates to the LKGR', async () => {
+    it('updates to master', async () => {
       await handleChromiumCheck();
 
       expect(roll).toHaveBeenCalledWith(expect.objectContaining({
@@ -178,8 +178,8 @@ describe('handleChromiumCheck()', () => {
       }));
     });
 
-    it('takes no action if LKGR is already in DEPS', async () => {
-      (getChromiumLkgr as jest.Mock).mockReturnValue({
+    it('takes no action if master is already in DEPS', async () => {
+      (getChromiumMaster as jest.Mock).mockReturnValue({
         commit: 'old-sha'
       });
       await handleChromiumCheck();

--- a/tests/utils/pr-text-spec.ts
+++ b/tests/utils/pr-text-spec.ts
@@ -14,20 +14,19 @@ describe('getPRText()', () => {
       };
       const prText = getPRText(target, details);
   
-      // correct title
+      // Correct title.
       expect(prText.title)
         .toBe(`chore: bump ${ROLL_TARGETS.node.name} to ${details.newVersion} (${details.branchName})`);
-      
-      // contains short description
+      // Contains short description.
       expect(prText.body)
         .toContain(`Updating Node.js to ${details.newVersion}.`);
-      // contains original node version reference
+      // Contains original Node.js version reference.
       expect(prText.body)
         .toContain(`Original-Version: ${details.previousVersion}`);
-      // contains release notes
+      // Contains release notes.
       expect(prText.body)
         .toContain(`Notes: Updated Node.js to ${details.newVersion}`);
-      // contains link to diff
+      // Contains link to Node.js diff.
       expect(prText.body)
         .toContain(`https://github.com/nodejs/node/compare/${details.previousVersion}...${details.newVersion}`);
     });
@@ -43,22 +42,21 @@ describe('getPRText()', () => {
 
       const prText = getPRText(target, details);
 
-      // correct title
+      // Correct title.
       expect(prText.title)
         .toContain(`chore: bump ${ROLL_TARGETS.chromium.name}`);
-      
-      // contains short description
+      // Contains short description.
       expect(prText.body)
         .toContain(`Updating Chromium`);
-      // contains original chromium version reference
+      // Contains original Chromium version reference
       expect(prText.body)
         .toContain(`Original-Version: ${details.previousVersion}`);
-      // contains link to diff
+      // Contains link to Chromium diff.
       expect(prText.body)
         .toContain(`https://chromium.googlesource.com/chromium/src/+log/${details.previousVersion}..${details.newVersion}?n=10000&pretty=fuller`);
     });
 
-    it('assumes LKGR if version is a commit SHA', () => {
+    it('assumes master if version is a commit SHA', () => {
       const target = ROLL_TARGETS.chromium;
       const details = {
         newVersion: '9F86D081884C7D659A2FEAA0C55',
@@ -68,7 +66,7 @@ describe('getPRText()', () => {
 
       const prText = getPRText(target, details);
 
-      expect(prText.body).toContain('(lkgr)');
+      expect(prText.body).toContain('(master)');
       expect(prText.body).toContain('no-notes');
     });
 


### PR DESCRIPTION
LGKR is not reliably updated anymore - we should roll on `master` instead to avoid ending up behind. We may end up needing to revert this depending on how bad commits filter down to us, but we'll see and iterate.

cc @nornagon 