### PR TITLE
fix: update supported branch pattern for 2 digit versions

### DIFF
--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -11,18 +11,28 @@ import { roll } from './utils/roll';
 export function getSupportedBranches(branches: { name: string }[]): string[] {
   const releaseBranches = branches
     .filter(branch => {
-      const releasePattern = /^[0-9]+-([0-9]+-x|x-y)$/;
+      const releasePattern = /^(\d)+-(?:(?:[0-9]+-x$)|(?:x+-y$))$/;
       return releasePattern.test(branch.name);
     })
     .map(b => b.name);
 
   const filtered: Record<string, string> = {};
-  releaseBranches.sort().forEach((branch: string) => {
-    return (filtered[branch.split('-')[0]] = branch);
-  });
+  releaseBranches
+    .sort((a, b) => {
+      const aParts = a.split('-');
+      const bParts = b.split('-');
+      for (let i = 0; i < aParts.length; i += 1) {
+        if (aParts[i] === bParts[i]) continue;
+        return parseInt(aParts[i], 10) - parseInt(bParts[i], 10);
+      }
+      return 0;
+    })
+    .forEach(branch => {
+      return (filtered[branch.split('-')[0]] = branch);
+    });
 
   const values = Object.values(filtered);
-  return values.sort().slice(-NUM_SUPPORTED_VERSIONS);
+  return values.sort((a, b) => parseInt(a, 10) - parseInt(b, 10)).slice(-NUM_SUPPORTED_VERSIONS);
 }
 
 export async function handleChromiumCheck(): Promise<void> {

--- a/tests/handlers-spec.ts
+++ b/tests/handlers-spec.ts
@@ -56,6 +56,18 @@ describe('handleChromiumCheck()', () => {
       this.mockOctokit.repos.listBranches.mockReturnValue({
         data: [
           {
+            name: '10-x-y',
+            commit: {
+              sha: '1234'
+            }
+          },
+          {
+            name: '9-x-y',
+            commit: {
+              sha: '1234'
+            }
+          },
+          {
             name: '8-x-y',
             commit: {
               sha: '1234'
@@ -100,7 +112,7 @@ describe('handleChromiumCheck()', () => {
       });
 
       const supported = getSupportedBranches(branches);
-      expect(supported).toEqual(['5-0-x', '6-1-x', '7-1-x', '8-x-y']);
+      expect(supported).toEqual(['7-1-x', '8-x-y', '9-x-y', '10-x-y']);
     });
 
     it('rolls with latest versions from release tags', async () => {


### PR DESCRIPTION
This PR updates roller to work with our 10-x-y branch.