### PR TITLE
fix: use omahaproxy release data

### DIFF
--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -82,20 +82,10 @@ export async function handleChromiumCheck(): Promise<void> {
     }
 
     d(`Computing latest upstream version for Chromium ${chromiumMajorVersion}`);
-    const upstreamVersions = [];
-    for (const r of chromiumReleases) {
-      if (/^win|win64|mac|linux$/.test(r.os)) {
-        for (const v of r.versions) {
-          if (
-            v.channel !== 'canary_asan' &&
-            Number(v.current_version.split('.')[0]) === chromiumMajorVersion
-          ) {
-            upstreamVersions.push(v.current_version);
-          }
-        }
-      }
-    }
-    upstreamVersions.sort(compareChromiumVersions);
+    const upstreamVersions = chromiumReleases
+      .filter(r => /^win|win64|mac|linux$/.test(r.os) && r.channel !== 'canary_asan' && Number(r.version.split('.')[0]) === chromiumMajorVersion)
+      .sort((a, b) => a.timestamp.localeCompare(b.timestamp))
+      .map(r => r.version);
     const latestUpstreamVersion = upstreamVersions[upstreamVersions.length - 1];
     if (compareChromiumVersions(latestUpstreamVersion, chromiumVersion) > 0) {
       d(

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -82,14 +82,18 @@ export async function handleChromiumCheck(): Promise<void> {
     }
 
     d(`Computing latest upstream version for Chromium ${chromiumMajorVersion}`);
-    const relevantChromiumReleases = chromiumReleases
-      .filter(r => r.os === 'win' || r.os === 'win64' || r.os === 'mac' || r.os === 'linux')
-    const upstreamVersions = []
+    const relevantChromiumReleases = chromiumReleases.filter(
+      r => r.os === 'win' || r.os === 'win64' || r.os === 'mac' || r.os === 'linux',
+    );
+    const upstreamVersions = [];
     for (const r of chromiumReleases) {
       if (r.os === 'win' || r.os === 'win64' || r.os === 'mac' || r.os === 'linux') {
         for (const v of r.versions) {
-          if (v.channel !== 'canary_asan' && Number(v.current_version.split('.')[0]) === chromiumMajorVersion) {
-            upstreamVersions.push(v.current_version)
+          if (
+            v.channel !== 'canary_asan' &&
+            Number(v.current_version.split('.')[0]) === chromiumMajorVersion
+          ) {
+            upstreamVersions.push(v.current_version);
           }
         }
       }

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -82,12 +82,9 @@ export async function handleChromiumCheck(): Promise<void> {
     }
 
     d(`Computing latest upstream version for Chromium ${chromiumMajorVersion}`);
-    const relevantChromiumReleases = chromiumReleases.filter(
-      r => r.os === 'win' || r.os === 'win64' || r.os === 'mac' || r.os === 'linux',
-    );
     const upstreamVersions = [];
     for (const r of chromiumReleases) {
-      if (r.os === 'win' || r.os === 'win64' || r.os === 'mac' || r.os === 'linux') {
+      if (/^win|win64|mac|linux$/.test(r.os)) {
         for (const v of r.versions) {
           if (
             v.channel !== 'canary_asan' &&

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -83,7 +83,12 @@ export async function handleChromiumCheck(): Promise<void> {
 
     d(`Computing latest upstream version for Chromium ${chromiumMajorVersion}`);
     const upstreamVersions = chromiumReleases
-      .filter(r => /^win|win64|mac|linux$/.test(r.os) && r.channel !== 'canary_asan' && Number(r.version.split('.')[0]) === chromiumMajorVersion)
+      .filter(
+        r =>
+          /^win|win64|mac|linux$/.test(r.os) &&
+          r.channel !== 'canary_asan' &&
+          Number(r.version.split('.')[0]) === chromiumMajorVersion,
+      )
       .sort((a, b) => a.timestamp.localeCompare(b.timestamp))
       .map(r => r.version);
     const latestUpstreamVersion = upstreamVersions[upstreamVersions.length - 1];

--- a/src/utils/get-chromium-tags.ts
+++ b/src/utils/get-chromium-tags.ts
@@ -30,11 +30,13 @@ export type OmahaReleaseVersion = {
 
 export type OmahaRelease = {
   os: 'win' | 'mac' | 'linux' | 'webview' | 'android' | 'cros' | 'ios' | 'win64';
-  versions: OmahaReleaseVersion[];
+  channel: 'stable' | 'beta' | 'dev' | 'canary' | 'canary_asan';
+  timestamp: string;
+  version: string;
 };
 
 export function getChromiumReleases(): Promise<OmahaRelease[]> {
-  return getJSON('https://omahaproxy.appspot.com/all.json');
+  return getJSON('https://omahaproxy.appspot.com/history.json');
 }
 
 export interface ChromiumCommit {

--- a/src/utils/get-chromium-tags.ts
+++ b/src/utils/get-chromium-tags.ts
@@ -26,15 +26,15 @@ export type OmahaReleaseVersion = {
   current_version: string;
   current_reldate: string;
   channel: string;
-}
+};
 
 export type OmahaRelease = {
   os: 'win' | 'mac' | 'linux' | 'webview' | 'android' | 'cros' | 'ios' | 'win64';
   versions: OmahaReleaseVersion[];
-}
+};
 
 export function getChromiumReleases(): Promise<OmahaRelease[]> {
-  return getJSON('https://omahaproxy.appspot.com/all.json')
+  return getJSON('https://omahaproxy.appspot.com/all.json');
 }
 
 export interface ChromiumCommit {

--- a/src/utils/get-chromium-tags.ts
+++ b/src/utils/get-chromium-tags.ts
@@ -22,8 +22,19 @@ function getJSON(url: string): Promise<any> {
   return get(url).then(s => JSON.parse(s.slice(s.indexOf('{'))));
 }
 
-export function getChromiumTags(): Promise<object> {
-  return getJSON('https://chromium.googlesource.com/chromium/src/+refs/tags?format=JSON');
+export type OmahaReleaseVersion = {
+  current_version: string;
+  current_reldate: string;
+  channel: string;
+}
+
+export type OmahaRelease = {
+  os: 'win' | 'mac' | 'linux' | 'webview' | 'android' | 'cros' | 'ios' | 'win64';
+  versions: OmahaReleaseVersion[];
+}
+
+export function getChromiumReleases(): Promise<OmahaRelease[]> {
+  return getJSON('https://omahaproxy.appspot.com/all.json')
 }
 
 export interface ChromiumCommit {

--- a/tests/handlers-spec.ts
+++ b/tests/handlers-spec.ts
@@ -1,7 +1,7 @@
 
 import { REPOS, ROLL_TARGETS } from '../src/constants';
 import { handleChromiumCheck, handleNodeCheck, getSupportedBranches } from '../src/handlers';
-import { getChromiumMaster, getChromiumTags } from '../src/utils/get-chromium-tags';
+import { getChromiumMaster, getChromiumReleases } from '../src/utils/get-chromium-tags';
 import { getOctokit } from '../src/utils/octokit';
 import { roll } from '../src/utils/roll';
 
@@ -39,17 +39,27 @@ describe('handleChromiumCheck()', () => {
           sha: '1234'
         },
       });
-      (getChromiumTags as jest.Mock).mockReturnValue({
-        "1.1.0.0": {
-          "value": "5678"
+      (getChromiumReleases as jest.Mock).mockReturnValue([
+        {
+          "os": "win",
+          "versions": [
+            {
+              "current_version": "1.1.0.0"
+            }
+          ]
         },
-        "1.2.0.0": {
-          "value": "5678"
+        {
+          "os": "mac",
+          "versions": [
+            {
+              "current_version": "2.1.0.0"
+            },
+            {
+              "current_version": "1.2.0.0"
+            }
+          ]
         },
-        "2.1.0.0": {
-          "value": "5678"
-        }
-      });
+      ]);
     });
 
     it('properly fetches supported versions of Electron to roll against', async () => {
@@ -218,17 +228,27 @@ describe('handleChromiumCheck()', () => {
         sha: '1234'
       },
     });
-    (getChromiumTags as jest.Mock).mockReturnValue({
-      "1.1.0.0": {
-        "value": "5678"
+    (getChromiumReleases as jest.Mock).mockReturnValue([
+      {
+        "os": "win",
+        "versions": [
+          {
+            "current_version": "1.1.0.0"
+          }
+        ]
       },
-      "1.2.0.0": {
-        "value": "5678"
+      {
+        "os": "mac",
+        "versions": [
+          {
+            "current_version": "2.1.0.0"
+          },
+          {
+            "current_version": "1.2.0.0"
+          }
+        ]
       },
-      "2.1.0.0": {
-        "value": "5678"
-      }
-    });
+    ]);
 
     (roll as jest.Mock).mockImplementationOnce(() => {
       throw new Error('');

--- a/tests/handlers-spec.ts
+++ b/tests/handlers-spec.ts
@@ -41,23 +41,22 @@ describe('handleChromiumCheck()', () => {
       });
       (getChromiumReleases as jest.Mock).mockReturnValue([
         {
-          "os": "win",
-          "versions": [
-            {
-              "current_version": "1.1.0.0"
-            }
-          ]
+          "timestamp": "2020-01-01 01:01:01.000001",
+          "version": "1.1.0.0",
+          "channel": "stable",
+          "os": "win"
         },
         {
-          "os": "mac",
-          "versions": [
-            {
-              "current_version": "2.1.0.0"
-            },
-            {
-              "current_version": "1.2.0.0"
-            }
-          ]
+          "timestamp": "2020-01-01 01:01:01.000003",
+          "version": "2.1.0.0",
+          "channel": "beta",
+          "os": "win"
+        },
+        {
+          "timestamp": "2020-01-01 01:01:01.000002",
+          "version": "1.2.0.0",
+          "channel": "stable",
+          "os": "mac"
         },
       ]);
     });
@@ -230,23 +229,22 @@ describe('handleChromiumCheck()', () => {
     });
     (getChromiumReleases as jest.Mock).mockReturnValue([
       {
-        "os": "win",
-        "versions": [
-          {
-            "current_version": "1.1.0.0"
-          }
-        ]
+        "timestamp": "2020-01-01 01:01:01.000001",
+        "version": "1.1.0.0",
+        "channel": "stable",
+        "os": "win"
       },
       {
-        "os": "mac",
-        "versions": [
-          {
-            "current_version": "2.1.0.0"
-          },
-          {
-            "current_version": "1.2.0.0"
-          }
-        ]
+        "timestamp": "2020-01-01 01:01:01.000003",
+        "version": "2.1.0.0",
+        "channel": "beta",
+        "os": "win"
+      },
+      {
+        "timestamp": "2020-01-01 01:01:01.000002",
+        "version": "1.2.0.0",
+        "channel": "stable",
+        "os": "mac"
       },
     ]);
 


### PR DESCRIPTION
Switch from using chromium's available tags to using [OmahaProxy](https://omahaproxy.appspot.com/) data for determining which Chromium versions to roll into Electron.

This will hopefully help us avoid issues like https://github.com/electron/electron/pull/25499 in the future.