### PR TITLE
fix: parsing of omahaproxy json

### DIFF
--- a/src/utils/get-chromium-tags.ts
+++ b/src/utils/get-chromium-tags.ts
@@ -36,7 +36,7 @@ export type OmahaRelease = {
 };
 
 export function getChromiumReleases(): Promise<OmahaRelease[]> {
-  return getJSON('https://omahaproxy.appspot.com/history.json');
+  return get('https://omahaproxy.appspot.com/history.json').then(s => JSON.parse(s));
 }
 
 export interface ChromiumCommit {


### PR DESCRIPTION
omahaproxy doesn't put the `]})` nonsense in front of its JSON.
