### PR TITLE
chore: log when no upgrade possible

### DIFF
--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -201,5 +201,7 @@ export async function handleNodeCheck(): Promise<void> {
       d(`Error rolling ${masterBranch.name} to ${latestUpstreamVersion}`, e);
       throw new Error(`Upgrade check failed - see logs for more details`);
     }
+  } else {
+    d(`No upgrade found, ${depsNodeVersion} is the most recent known in its release line.`);
   }
 }


### PR DESCRIPTION
Tiny change - we should log when no upgrade is possible for Node.js to 

1) match behavior for Chrome roll logic
2) make parsing logs easier

cc @nornagon @MarshallOfSound 