### PR TITLE
chore: roll master to chromium version instead of SHA

### DIFF
--- a/src/utils/get-chromium-tags.ts
+++ b/src/utils/get-chromium-tags.ts
@@ -64,7 +64,3 @@ export function getChromiumCommits(
     `https://chromium.googlesource.com/chromium/src/+log/${fromRef}..${toRef}?format=JSON`,
   );
 }
-
-export function getChromiumMaster(): Promise<any> {
-  return getJSON(`https://chromium.googlesource.com/chromium/src/+/refs/heads/master?format=JSON`);
-}


### PR DESCRIPTION
As discussed in upgrades-wg this morning, this is backwards compatible so on merge the next roll commit will move us to a version number