### PR TITLE
fix: 'test' and 'lint' are both failing

### DIFF
--- a/src/utils/roll.ts
+++ b/src/utils/roll.ts
@@ -31,7 +31,9 @@ export async function roll({
     state: 'open',
   })) as PullsListResponseItem[];
 
-  const prs = existingPrsForBranch.filter(pr => pr.title.startsWith(`chore: bump ${rollTarget.name}`));
+  const prs = existingPrsForBranch.filter(pr =>
+    pr.title.startsWith(`chore: bump ${rollTarget.name}`),
+  );
 
   if (prs.length) {
     // Update existing PR(s)

--- a/tests/handlers-spec.ts
+++ b/tests/handlers-spec.ts
@@ -197,7 +197,7 @@ describe('handleChromiumCheck()', () => {
         {
           "timestamp": "2020-01-01 01:01:01.000003",
           "version": "2.1.0.0",
-          "channel": "beta",
+          "channel": "canary",
           "os": "win"
         },
         {
@@ -221,13 +221,13 @@ describe('handleChromiumCheck()', () => {
         {
           "timestamp": "2020-01-01 01:01:01.000001",
           "version": "1.1.0.0",
-          "channel": "stable",
+          "channel": "canary",
           "os": "win"
         },
         {
           "timestamp": "2020-01-01 01:01:01.000002",
           "version": "1.1.0.0",
-          "channel": "stable",
+          "channel": "canary",
           "os": "mac"
         },
       ]);

--- a/tests/utils/roll-spec.ts
+++ b/tests/utils/roll-spec.ts
@@ -53,7 +53,7 @@ describe('roll()', () => {
         user: {
           login: PR_USER
         },
-        title: ROLL_TARGETS.node.name,
+        title: `chore: bump ${ROLL_TARGETS.node.name} to foo`,
         number: 1,
         head: {
           ref: 'asd'
@@ -88,7 +88,7 @@ describe('roll()', () => {
         user: {
           login: PR_USER
         },
-        title: ROLL_TARGETS.node.name,
+        title: `chore: bump ${ROLL_TARGETS.node.name} to bar`,
         number: 1,
         head: {
           ref: 'asd'


### PR DESCRIPTION
This gets roller green again.

* lint: ran `prettier:write`
* roll-spec: sync to e2e9b2a3d5b63f80d3497821f2744fb8f798428e
* handlers-spec: sync to 81e60c450ccd4e1c0e512029cdfaf2c9bdac1a50