### PR TITLE
fix: disable trop backport checks for PRs to older branches

### DIFF
--- a/src/utils/roll.ts
+++ b/src/utils/roll.ts
@@ -122,7 +122,7 @@ export async function roll({
     await github.issues.addLabels({
       ...REPOS.electron,
       issue_number: newPr.data.number,
-      labels: ['semver/patch', 'no-backport'],
+      labels: ['semver/patch', 'no-backport', 'backport-check-skip'],
     });
     d(`New PR: ${newPr.data.html_url}`);
     // TODO: add comment with commit list to new PR.


### PR DESCRIPTION
Saw this here https://github.com/electron/electron/pull/29321

We should add the `backport-check-skip` label so trop doesn't hell at roller. 