### PR TITLE
fix: backport labels for branches

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -22,7 +22,8 @@ export const ROLL_TARGETS = {
   },
 };
 
-export const PR_USER = 'electron-bot';
+export const BACKPORT_CHECK_SKIP = 'backport-check-skip';
+export const NO_BACKPORT = 'no-backport';
 
 export interface Commit {
   sha: string;

--- a/src/utils/roll.ts
+++ b/src/utils/roll.ts
@@ -1,7 +1,7 @@
 import { PullsListResponseItem, ReposListBranchesResponseItem } from '@octokit/rest';
 import * as debug from 'debug';
 
-import { PR_USER, REPOS, RollTarget } from '../constants';
+import { BACKPORT_CHECK_SKIP, NO_BACKPORT, REPOS, RollTarget } from '../constants';
 import { getOctokit } from './octokit';
 import { getPRText } from './pr-text';
 import { updateDepsFile } from './update-deps';
@@ -119,11 +119,15 @@ export async function roll({
         branchName: electronBranch.name,
       }),
     });
+
+    const labels = ['semver/patch'];
+    labels.push(branchName === 'main' ? NO_BACKPORT : BACKPORT_CHECK_SKIP);
+
     // Although not completely correct, it's the best we've got :)
     await github.issues.addLabels({
       ...REPOS.electron,
       issue_number: newPr.data.number,
-      labels: ['semver/patch', 'no-backport', 'backport-check-skip'],
+      labels,
     });
     d(`New PR: ${newPr.data.html_url}`);
     // TODO: add comment with commit list to new PR.

--- a/tests/utils/roll-spec.ts
+++ b/tests/utils/roll-spec.ts
@@ -1,6 +1,6 @@
 import { roll } from '../../src/utils/roll';
 import { getOctokit } from '../../src/utils/octokit';
-import { ROLL_TARGETS, PR_USER, REPOS } from '../../src/constants';
+import { ROLL_TARGETS, REPOS } from '../../src/constants';
 import { updateDepsFile } from '../../src/utils/update-deps';
 
 jest.mock('../../src/utils/octokit');
@@ -11,17 +11,17 @@ describe('roll()', () => {
     name: 'testBranch',
     commit: {
       sha: 'asdsad',
-      url: 'asdsadsad'
+      url: 'asdsadsad',
     },
     protected: true,
     protection: {
       enabled: false,
       required_status_checks: {
         enforcement_level: '',
-        contexts: []
-      }
+        contexts: [],
+      },
     },
-    protection_url: 'asdasd'
+    protection_url: 'asdasd',
   };
 
   beforeEach(() => {
@@ -29,53 +29,82 @@ describe('roll()', () => {
       paginate: jest.fn(),
       pulls: {
         update: jest.fn(),
-        create: jest.fn().mockReturnValue({data: {html_url: 'https://google.com'}})
+        create: jest.fn().mockReturnValue({ data: { html_url: 'https://google.com' } }),
       },
       git: {
         createRef: jest.fn(),
-        getRef: jest.fn().mockReturnValue({status: 404}),
-        deleteRef: jest.fn()
+        getRef: jest.fn().mockReturnValue({ status: 404 }),
+        deleteRef: jest.fn(),
       },
       issues: {
         addLabels: jest.fn(),
-      }
+      },
     };
     (getOctokit as jest.Mock).mockReturnValue(this.mockOctokit);
     (updateDepsFile as jest.Mock).mockReturnValue({
       previousDEPSVersion: 'v4.0.0',
-      newDEPSVersion: 'v10.0.0'
+      newDEPSVersion: 'v10.0.0',
     });
   });
-  
+
   it('takes no action if versions are identical', async () => {
-    this.mockOctokit.paginate.mockReturnValue(
-      [{
+    this.mockOctokit.paginate.mockReturnValue([
+      {
         user: {
-          login: PR_USER
+          login: 'electron-roller[bot]',
         },
         title: `chore: bump ${ROLL_TARGETS.node.name} to foo`,
         number: 1,
         head: {
-          ref: 'asd'
+          ref: 'asd',
         },
         body: 'Original-Version: v4.0.0',
-        labels: [
-          { name: 'hello' },
-          { name: 'goodbye' }
-        ],
-        created_at: (new Date()).toISOString()
-      }]
-    );
+        labels: [{ name: 'hello' }, { name: 'goodbye' }],
+        created_at: new Date().toISOString(),
+      },
+    ]);
 
     (updateDepsFile as jest.Mock).mockReturnValue({
       previousDEPSVersion: 'v4.0.0',
-      newDEPSVersion: 'v4.0.0'
+      newDEPSVersion: 'v4.0.0',
     });
 
     await roll({
       rollTarget: ROLL_TARGETS.node,
       electronBranch: branch,
-      targetVersion: 'v4.0.0'
+      targetVersion: 'v4.0.0',
+    });
+
+    expect(this.mockOctokit.pulls.update).not.toHaveBeenCalled();
+    expect(this.mockOctokit.pulls.create).not.toHaveBeenCalled();
+  });
+
+  it('takes no action if the PR user is trop', async () => {
+    this.mockOctokit.paginate.mockReturnValue([
+      {
+        user: {
+          login: 'trop[bot]',
+        },
+        title: `chore: bump ${ROLL_TARGETS.node.name} to foo`,
+        number: 1,
+        head: {
+          ref: 'asd',
+        },
+        body: 'Original-Version: v4.0.0',
+        labels: [{ name: 'hello' }, { name: 'goodbye' }],
+        created_at: new Date().toISOString(),
+      },
+    ]);
+
+    (updateDepsFile as jest.Mock).mockReturnValue({
+      previousDEPSVersion: 'v4.0.0',
+      newDEPSVersion: 'v4.0.0',
+    });
+
+    await roll({
+      rollTarget: ROLL_TARGETS.node,
+      electronBranch: branch,
+      targetVersion: 'v4.0.0',
     });
 
     expect(this.mockOctokit.pulls.update).not.toHaveBeenCalled();
@@ -83,37 +112,38 @@ describe('roll()', () => {
   });
 
   it('updates a PR if existing PR already exists', async () => {
-    this.mockOctokit.paginate.mockReturnValue(
-      [{
+    this.mockOctokit.paginate.mockReturnValue([
+      {
         user: {
-          login: PR_USER
+          login: 'electron-roller[bot]',
         },
         title: `chore: bump ${ROLL_TARGETS.node.name} to bar`,
         number: 1,
         head: {
-          ref: 'asd'
+          ref: 'asd',
         },
         body: 'Original-Version: v4.0.0',
-        labels: [
-          { name: 'hello' },
-          { name: 'goodbye' }
-        ],
-        created_at: (new Date()).toISOString()
-      }]
-    );
+        labels: [{ name: 'hello' }, { name: 'goodbye' }],
+        created_at: new Date().toISOString(),
+      },
+    ]);
 
     await roll({
       rollTarget: ROLL_TARGETS.node,
       electronBranch: branch,
-      targetVersion: 'v10.0.0'
+      targetVersion: 'v10.0.0',
     });
 
-    expect(this.mockOctokit.pulls.update).toHaveBeenCalledWith(expect.objectContaining({
-      ...REPOS.electron,
-      pull_number: 1,
-      title: expect.stringContaining(`bump ${ROLL_TARGETS.node.name} to v10.0.0 (${branch.name})`),
-      body: expect.stringContaining('Original-Version: v4.0.0'),
-    }));
+    expect(this.mockOctokit.pulls.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ...REPOS.electron,
+        pull_number: 1,
+        title: expect.stringContaining(
+          `bump ${ROLL_TARGETS.node.name} to v10.0.0 (${branch.name})`,
+        ),
+        body: expect.stringContaining('Original-Version: v4.0.0'),
+      }),
+    );
   });
 
   it('creates a new PR if none found', async () => {
@@ -122,7 +152,7 @@ describe('roll()', () => {
     await roll({
       rollTarget: ROLL_TARGETS.node,
       electronBranch: branch,
-      targetVersion: 'v10.0.0'
+      targetVersion: 'v10.0.0',
     });
 
     const newBranchName = `roller/${ROLL_TARGETS.node.name}/${branch.name}`;
@@ -130,41 +160,41 @@ describe('roll()', () => {
     expect(this.mockOctokit.git.createRef).toHaveBeenCalledWith({
       ...REPOS.electron,
       ref: `refs/heads/${newBranchName}`,
-      sha: branch.commit.sha
+      sha: branch.commit.sha,
     });
 
-    expect(this.mockOctokit.pulls.create).toHaveBeenCalledWith(expect.objectContaining({
-      ...REPOS.electron,
-      base: branch.name,
-      head: `${REPOS.electron.owner}:${newBranchName}`
-    }));
+    expect(this.mockOctokit.pulls.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ...REPOS.electron,
+        base: branch.name,
+        head: `${REPOS.electron.owner}:${newBranchName}`,
+      }),
+    );
   });
 
   it('skips PR if existing one has been paused', async () => {
-    this.mockOctokit.paginate.mockReturnValue(
-      [{
+    this.mockOctokit.paginate.mockReturnValue([
+      {
         user: {
-          login: PR_USER
+          login: 'electron-roller[bot]',
         },
         title: ROLL_TARGETS.node.name,
         number: 1,
         head: {
-          ref: 'asd'
+          ref: 'asd',
         },
         body: 'Original-Version: v4.0.0',
-        labels: [
-          { name: 'roller/pause' }
-        ],
-        created_at: (new Date('December 17, 1995 03:24:00')).toISOString()
-      }]
-    );
+        labels: [{ name: 'roller/pause' }],
+        created_at: new Date('December 17, 1995 03:24:00').toISOString(),
+      },
+    ]);
 
     await roll({
       rollTarget: ROLL_TARGETS.node,
       electronBranch: branch,
-      targetVersion: 'v10.0.0'
+      targetVersion: 'v10.0.0',
     });
 
     expect(this.mockOctokit.pulls.update).not.toHaveBeenCalled();
-  })
+  });
 });


### PR DESCRIPTION
`main` PRs should have the `no-backport` label applied, and release branches should have the `backport-check-skip` label applied.

Other small changes 
* We don't need `PR_USER` as a constant 
* We should test that trop PRs don't trigger any action
* Prettier on test files