### PR TITLE
chore: remove unused master codepaths

### DIFF
--- a/src/chromium-cron.ts
+++ b/src/chromium-cron.ts
@@ -1,6 +1,6 @@
 import { handleChromiumCheck } from './handlers';
 
-if (process.mainModule === module) {
+if (require.main === module) {
   handleChromiumCheck().catch(err => {
     console.log('Chromium Cron Failed');
     console.error(err);

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -9,6 +9,8 @@ export const REPOS = {
   },
 };
 
+export const MAIN_BRANCH = 'main';
+
 export const NUM_SUPPORTED_VERSIONS = 4;
 
 export const ROLL_TARGETS = {

--- a/src/node-cron.ts
+++ b/src/node-cron.ts
@@ -1,6 +1,6 @@
 import { handleNodeCheck } from './handlers';
 
-if (process.mainModule === module) {
+if (require.main === module) {
   handleNodeCheck().catch(err => {
     console.log('Node Cron Failed');
     console.error(err);


### PR DESCRIPTION
Removes handling for dual master/main branches introduced in https://github.com/electron/roller/pull/70.

Also adds some extra type checks which were missing for the main branch in Chromium rolls.