### PR TITLE
test: fix missing jest mock

### DIFF
--- a/tests/handlers-spec.ts
+++ b/tests/handlers-spec.ts
@@ -17,6 +17,14 @@ describe('handleChromiumCheck()', () => {
         listBranches: jest.fn(),
         getContent: jest.fn(),
         get: jest.fn(),
+        getBranch: jest.fn().mockReturnValue({
+          data: {
+            name: MAIN_BRANCH,
+            commit: {
+              sha: '1234',
+            },
+          },
+        }),
       },
     };
     (getOctokit as jest.Mock).mockReturnValue(mockOctokit);


### PR DESCRIPTION
Fixes failure borne of missing jest mock for `octokit.repos.getBranch`