### PR TITLE
fix: use chromiumdash instead of omahaproxy for release data

### DIFF
--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -91,11 +91,10 @@ export async function handleChromiumCheck(): Promise<void> {
     const upstreamVersions = chromiumReleases
       .filter(
         r =>
-          /^win|win64|mac|linux$/.test(r.os) &&
-          r.channel !== 'canary_asan' &&
-          Number(r.version.split('.')[0]) === chromiumMajorVersion,
+          ['Win32', 'Windows', 'Linux', 'Mac'].includes(r.platform) &&
+          r.milestone === chromiumMajorVersion,
       )
-      .sort((a, b) => a.timestamp.localeCompare(b.timestamp))
+      .sort((a, b) => a.time - b.time)
       .map(r => r.version);
     const latestUpstreamVersion = upstreamVersions[upstreamVersions.length - 1];
     if (
@@ -156,8 +155,10 @@ export async function handleChromiumCheck(): Promise<void> {
   }
 
   const upstreamVersions = chromiumReleases
-    .filter(r => /^win|win64|mac|linux$/.test(r.os) && r.channel === 'canary')
-    .sort((a, b) => a.timestamp.localeCompare(b.timestamp))
+    .filter(
+      r => ['Windows', 'Win32', 'Linux', 'Mac'].includes(r.platform) && r.channel === 'Canary',
+    )
+    .sort((a, b) => a.time - b.time)
     .map(r => r.version);
   const latestUpstreamVersion = upstreamVersions[upstreamVersions.length - 1];
 

--- a/src/utils/get-chromium-tags.ts
+++ b/src/utils/get-chromium-tags.ts
@@ -22,21 +22,16 @@ function getJSON(url: string): Promise<any> {
   return get(url).then(s => JSON.parse(s.slice(s.indexOf('{'))));
 }
 
-export type OmahaReleaseVersion = {
-  current_version: string;
-  current_reldate: string;
-  channel: string;
-};
-
-export type OmahaRelease = {
-  os: 'win' | 'mac' | 'linux' | 'webview' | 'android' | 'cros' | 'ios' | 'win64';
-  channel: 'stable' | 'beta' | 'dev' | 'canary' | 'canary_asan';
-  timestamp: string;
+export type Release = {
+  platform: 'Android' | 'Linux' | 'Mac' | 'Webview' | 'Win32' | 'Windows' | 'iOS';
+  channel: 'Extended' | 'Stable' | 'Beta' | 'Dev' | 'Canary';
+  milestone: number;
+  time: number;
   version: string;
 };
 
-export function getChromiumReleases(): Promise<OmahaRelease[]> {
-  return get('https://omahaproxy.appspot.com/history.json').then(s => JSON.parse(s));
+export function getChromiumReleases(): Promise<Release[]> {
+  return get('https://chromiumdash.appspot.com/fetch_releases').then(s => JSON.parse(s));
 }
 
 export interface ChromiumCommit {

--- a/tests/handlers-spec.ts
+++ b/tests/handlers-spec.ts
@@ -51,22 +51,25 @@ describe('handleChromiumCheck()', () => {
       });
       (getChromiumReleases as jest.Mock).mockReturnValue([
         {
-          timestamp: '2020-01-01 01:01:01.000001',
+          time: 1577869261000,
           version: '1.1.0.0',
-          channel: 'stable',
-          os: 'win',
+          milestone: 1,
+          channel: 'Stable',
+          platform: 'Windows',
         },
         {
-          timestamp: '2020-01-01 01:01:01.000003',
+          time: 1577869261003,
           version: '2.1.0.0',
-          channel: 'beta',
-          os: 'win',
+          milestone: 2,
+          channel: 'Beta',
+          platform: 'Windows',
         },
         {
-          timestamp: '2020-01-01 01:01:01.000002',
+          time: 1577869261002,
           version: '1.2.0.0',
-          channel: 'stable',
-          os: 'mac',
+          milestone: 1,
+          channel: 'Stable',
+          platform: 'Mac',
         },
       ]);
     });
@@ -207,22 +210,25 @@ describe('handleChromiumCheck()', () => {
     it('updates to main', async () => {
       (getChromiumReleases as jest.Mock).mockReturnValue([
         {
-          timestamp: '2020-01-01 01:01:01.000001',
+          time: 1577869261000,
           version: '1.1.0.0',
-          channel: 'stable',
-          os: 'win',
+          milestone: 1,
+          channel: 'Stable',
+          platform: 'Windows',
         },
         {
-          timestamp: '2020-01-01 01:01:01.000003',
+          time: 1577869261003,
           version: '2.1.0.0',
-          channel: 'canary',
-          os: 'win',
+          milestone: 2,
+          channel: 'Canary',
+          platform: 'Windows',
         },
         {
-          timestamp: '2020-01-01 01:01:01.000002',
+          time: 1577869261002,
           version: '1.2.0.0',
-          channel: 'stable',
-          os: 'mac',
+          milestone: 1,
+          channel: 'Stable',
+          platform: 'Mac',
         },
       ]);
 
@@ -239,16 +245,18 @@ describe('handleChromiumCheck()', () => {
     it('takes no action if main is already in DEPS', async () => {
       (getChromiumReleases as jest.Mock).mockReturnValue([
         {
-          timestamp: '2020-01-01 01:01:01.000001',
+          time: 1577869261000,
           version: '1.1.0.0',
-          channel: 'canary',
-          os: 'win',
+          milestone: 1,
+          channel: 'Canary',
+          platform: 'Windows',
         },
         {
-          timestamp: '2020-01-01 01:01:01.000002',
+          time: 1577869261001,
           version: '1.1.0.0',
-          channel: 'canary',
-          os: 'mac',
+          milestone: 1,
+          channel: 'Canary',
+          platform: 'Mac',
         },
       ]);
 
@@ -278,22 +286,25 @@ describe('handleChromiumCheck()', () => {
     });
     (getChromiumReleases as jest.Mock).mockReturnValue([
       {
-        timestamp: '2020-01-01 01:01:01.000001',
+        time: 1577869261000,
         version: '1.1.0.0',
-        channel: 'stable',
-        os: 'win',
+        milestone: 1,
+        channel: 'Stable',
+        platform: 'Windows',
       },
       {
-        timestamp: '2020-01-01 01:01:01.000003',
+        time: 1577869261003,
         version: '2.1.0.0',
-        channel: 'beta',
-        os: 'win',
+        milestone: 2,
+        channel: 'Beta',
+        platform: 'Windows',
       },
       {
-        timestamp: '2020-01-01 01:01:01.000002',
+        time: 1577869261002,
         version: '1.2.0.0',
-        channel: 'stable',
-        os: 'mac',
+        milestone: 1,
+        channel: 'Stable',
+        platform: 'Mac',
       },
     ]);
 


### PR DESCRIPTION
This will hopefully get us Extended Stable data, which omahaproxy lacks.
