### PR TITLE
feat: enable branch specific rolling

### DIFF
--- a/src/chromium-cron.ts
+++ b/src/chromium-cron.ts
@@ -1,4 +1,4 @@
-import { handleChromiumCheck } from './handlers';
+import { handleChromiumCheck } from './chromium-handler';
 
 if (require.main === module) {
   handleChromiumCheck().catch(err => {

--- a/src/chromium-handler.ts
+++ b/src/chromium-handler.ts
@@ -1,42 +1,14 @@
 import * as debug from 'debug';
-import * as semver from 'semver';
 
-import { MAIN_BRANCH, NUM_SUPPORTED_VERSIONS, REPOS, ROLL_TARGETS } from './constants';
-import { ReposListBranchesResponseItem } from './types';
+import { MAIN_BRANCH, REPOS, ROLL_TARGETS } from './constants';
 import { compareChromiumVersions } from './utils/compare-chromium-versions';
 import { getChromiumReleases } from './utils/get-chromium-tags';
+import { getSupportedBranches } from './utils/get-supported-branches';
 import { getOctokit } from './utils/octokit';
 import { roll } from './utils/roll';
+import { ReposListBranchesResponseItem } from './types';
 
-// Get array of currently supported branches
-export function getSupportedBranches(branches: { name: string }[]): string[] {
-  const releaseBranches = branches
-    .filter(branch => {
-      const releasePattern = /^(\d)+-(?:(?:[0-9]+-x$)|(?:x+-y$))$/;
-      return releasePattern.test(branch.name);
-    })
-    .map(b => b.name);
-
-  const filtered: Record<string, string> = {};
-  releaseBranches
-    .sort((a, b) => {
-      const aParts = a.split('-');
-      const bParts = b.split('-');
-      for (let i = 0; i < aParts.length; i += 1) {
-        if (aParts[i] === bParts[i]) continue;
-        return parseInt(aParts[i], 10) - parseInt(bParts[i], 10);
-      }
-      return 0;
-    })
-    .forEach(branch => {
-      return (filtered[branch.split('-')[0]] = branch);
-    });
-
-  const values = Object.values(filtered);
-  return values.sort((a, b) => parseInt(a, 10) - parseInt(b, 10)).slice(-NUM_SUPPORTED_VERSIONS);
-}
-
-export async function handleChromiumCheck(): Promise<void> {
+export async function handleChromiumCheck(target?: string): Promise<void> {
   const d = debug('roller/chromium:handleChromiumCheck()');
   d('Fetching Chromium releases');
   const chromiumReleases = await getChromiumReleases();
@@ -181,65 +153,5 @@ export async function handleChromiumCheck(): Promise<void> {
 
   if (!thisIsFine) {
     throw new Error('One or more upgrade checks failed - see logs for more details');
-  }
-}
-
-export async function handleNodeCheck(): Promise<void> {
-  const d = debug('roller/node:handleNodeCheck()');
-  const github = await getOctokit();
-
-  d('Fetching nodejs/node releases');
-  const { data: releases } = await github.repos.listReleases({
-    owner: REPOS.node.owner,
-    repo: REPOS.node.repo,
-  });
-  const releaseTags = releases.map(r => r.tag_name);
-
-  d(`Fetching ${MAIN_BRANCH} branch from electron/electron`);
-  const { data: mainBranch } = await github.repos.getBranch({
-    ...REPOS.electron,
-    branch: MAIN_BRANCH,
-  });
-
-  d(`Fetching DEPS for branch ${mainBranch.name} in electron/electron`);
-  const { data: depsData } = await github.repos.getContent({
-    owner: REPOS.electron.owner,
-    repo: REPOS.electron.repo,
-    path: 'DEPS',
-    ref: MAIN_BRANCH,
-  });
-
-  if (!('content' in depsData)) {
-    d(`Error - incorrectly got array when fetching DEPS content for ${MAIN_BRANCH}`);
-    throw new Error(`Upgrade check failed - see logs for more details`);
-  }
-
-  const deps = Buffer.from(depsData.content, 'base64').toString('utf8');
-
-  // find node version from DEPS
-  const versionRegex = new RegExp(`${ROLL_TARGETS.node.depsKey}':\n +'(.+?)',`, 'm');
-  const [, depsNodeVersion] = versionRegex.exec(deps);
-  const majorVersion = semver.major(semver.clean(depsNodeVersion));
-
-  d(`Computing latest upstream version for Node ${majorVersion}`);
-  const latestUpstreamVersion = semver.maxSatisfying(releaseTags, `^${majorVersion}`);
-
-  // Only roll for LTS release lines of Node.js (even-numbered major versions).
-  if (majorVersion % 2 === 0 && semver.gt(latestUpstreamVersion, depsNodeVersion)) {
-    d(
-      `Upgrade possible: ${mainBranch.name} can roll from ${depsNodeVersion} to ${latestUpstreamVersion}`,
-    );
-    try {
-      await roll({
-        rollTarget: ROLL_TARGETS.node,
-        electronBranch: mainBranch,
-        targetVersion: latestUpstreamVersion,
-      });
-    } catch (e) {
-      d(`Error rolling ${mainBranch.name} to ${latestUpstreamVersion}`, e);
-      throw new Error(`Upgrade check failed - see logs for more details`);
-    }
-  } else {
-    d(`No upgrade found - ${depsNodeVersion} is the most recent known in its release line.`);
   }
 }

--- a/src/chromium-handler.ts
+++ b/src/chromium-handler.ts
@@ -2,13 +2,82 @@ import * as debug from 'debug';
 
 import { MAIN_BRANCH, REPOS, ROLL_TARGETS } from './constants';
 import { compareChromiumVersions } from './utils/compare-chromium-versions';
-import { getChromiumReleases } from './utils/get-chromium-tags';
+import { getChromiumReleases, Release } from './utils/get-chromium-tags';
 import { getSupportedBranches } from './utils/get-supported-branches';
 import { getOctokit } from './utils/octokit';
 import { roll } from './utils/roll';
 import { ReposListBranchesResponseItem } from './types';
+import { Octokit } from '@octokit/rest';
 
-export async function handleChromiumCheck(target?: string): Promise<void> {
+async function rollReleaseBranch(
+  github: Octokit,
+  branch: ReposListBranchesResponseItem,
+  chromiumReleases: Release[],
+) {
+  const d = debug(`roller/chromium:rollReleaseBranch('${branch}')`);
+
+  d(`Fetching DEPS for ${branch.name}`);
+  const { data: depsData } = await github.repos.getContent({
+    ...REPOS.electron,
+    path: 'DEPS',
+    ref: branch.commit.sha,
+  });
+
+  if (!('content' in depsData)) {
+    throw new Error(`Error - incorrectly got array when fetching DEPS content for ${branch}`);
+  }
+
+  const deps = Buffer.from(depsData.content, 'base64').toString('utf8');
+  const versionRegex = new RegExp(`${ROLL_TARGETS.chromium.depsKey}':\n +'(.+?)',`, 'm');
+  const [, chromiumVersion] = versionRegex.exec(deps);
+
+  const chromiumMajorVersion = Number(chromiumVersion.split('.')[0]);
+
+  // We should be able to parse major version as a number.
+  if (Number.isNaN(chromiumMajorVersion)) {
+    const SHAPattern = /\b[0-9a-f]{5,40}\b/;
+    // On newer release branches we may not yet have updated the branch to use tags
+    if (`${chromiumMajorVersion}`.match(SHAPattern)) {
+      throw new Error(`${branch.name} roll failed: ${chromiumMajorVersion} should be a tag.`);
+    } else {
+      throw new Error(
+        `${branch.name} roll failed: ${chromiumVersion} is not a valid version number`,
+      );
+    }
+  }
+
+  d(`Computing latest upstream version for Chromium ${chromiumMajorVersion}`);
+  const upstreamVersions = chromiumReleases
+    .filter(
+      r =>
+        ['Win32', 'Windows', 'Linux', 'Mac'].includes(r.platform) &&
+        r.milestone === chromiumMajorVersion,
+    )
+    .sort((a, b) => a.time - b.time)
+    .map(r => r.version);
+  const latestUpstreamVersion = upstreamVersions[upstreamVersions.length - 1];
+  if (
+    latestUpstreamVersion &&
+    compareChromiumVersions(latestUpstreamVersion, chromiumVersion) > 0
+  ) {
+    d(
+      `Upgrade possible: ${branch.name} can roll from ${chromiumVersion} to ${latestUpstreamVersion}`,
+    );
+    try {
+      await roll({
+        rollTarget: ROLL_TARGETS.chromium,
+        electronBranch: branch,
+        targetVersion: latestUpstreamVersion,
+      });
+    } catch (e) {
+      throw new Error(`Error rolling ${branch.name} to ${latestUpstreamVersion}: ${e.message}`);
+    }
+  } else {
+    d(`No upgrade found, ${chromiumVersion} is the most recent known in its release line.`);
+  }
+}
+
+export async function handleChromiumCheck(): Promise<void> {
   const d = debug('roller/chromium:handleChromiumCheck()');
   d('Fetching Chromium releases');
   const chromiumReleases = await getChromiumReleases();
@@ -30,68 +99,7 @@ export async function handleChromiumCheck(target?: string): Promise<void> {
 
   // Roll all non-main release branches.
   for (const branch of releaseBranches) {
-    d(`Fetching DEPS for ${branch.name}`);
-    const { data: depsData } = await github.repos.getContent({
-      ...REPOS.electron,
-      path: 'DEPS',
-      ref: branch.commit.sha,
-    });
-
-    if (!('content' in depsData)) {
-      d(`Error - incorrectly got array when fetching DEPS content for ${branch}`);
-      thisIsFine = false;
-      continue;
-    }
-
-    const deps = Buffer.from(depsData.content, 'base64').toString('utf8');
-    const versionRegex = new RegExp(`${ROLL_TARGETS.chromium.depsKey}':\n +'(.+?)',`, 'm');
-    const [, chromiumVersion] = versionRegex.exec(deps);
-
-    const chromiumMajorVersion = Number(chromiumVersion.split('.')[0]);
-
-    // We should be able to parse major version as a number.
-    if (Number.isNaN(chromiumMajorVersion)) {
-      const SHAPattern = /\b[0-9a-f]{5,40}\b/;
-      // On newer release branches we may not yet have updated the branch to use tags
-      if (`${chromiumMajorVersion}`.match(SHAPattern)) {
-        d(`${branch.name} roll failed: ${chromiumMajorVersion} should be a tag.`);
-      } else {
-        d(`${branch.name} roll failed: ${chromiumVersion} is not a valid version number`);
-      }
-      thisIsFine = false;
-      continue;
-    }
-
-    d(`Computing latest upstream version for Chromium ${chromiumMajorVersion}`);
-    const upstreamVersions = chromiumReleases
-      .filter(
-        r =>
-          ['Win32', 'Windows', 'Linux', 'Mac'].includes(r.platform) &&
-          r.milestone === chromiumMajorVersion,
-      )
-      .sort((a, b) => a.time - b.time)
-      .map(r => r.version);
-    const latestUpstreamVersion = upstreamVersions[upstreamVersions.length - 1];
-    if (
-      latestUpstreamVersion &&
-      compareChromiumVersions(latestUpstreamVersion, chromiumVersion) > 0
-    ) {
-      d(
-        `Upgrade possible: ${branch.name} can roll from ${chromiumVersion} to ${latestUpstreamVersion}`,
-      );
-      try {
-        await roll({
-          rollTarget: ROLL_TARGETS.chromium,
-          electronBranch: branch,
-          targetVersion: latestUpstreamVersion,
-        });
-      } catch (e) {
-        d(`Error rolling ${branch.name} to ${latestUpstreamVersion}: `, e);
-        thisIsFine = false;
-      }
-    } else {
-      d(`No upgrade found, ${chromiumVersion} is the most recent known in its release line.`);
-    }
+    await rollReleaseBranch(github, branch, chromiumReleases);
   }
 
   d(`Fetching ${MAIN_BRANCH} branch for electron/electron`);

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -27,6 +27,8 @@ export const ROLL_TARGETS = {
 export const BACKPORT_CHECK_SKIP = 'backport-check-skip';
 export const NO_BACKPORT = 'no-backport';
 
+export const ROLLER_CMD_PREFIX = '/roll';
+
 export interface Commit {
   sha: string;
   message: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,8 @@
 import * as debug from 'debug';
 import { Context, Probot } from 'probot';
 import { IssueCommentCreatedEvent, PullRequestClosedEvent } from '@octokit/webhooks-types';
-import { handleChromiumCheck, handleNodeCheck } from './handlers';
+import { handleNodeCheck } from './node-handler';
+import { handleChromiumCheck } from './chromium-handler';
 import { ROLL_TARGETS } from './constants';
 
 const d = debug('Autorolling On Merge');

--- a/src/node-cron.ts
+++ b/src/node-cron.ts
@@ -1,4 +1,4 @@
-import { handleNodeCheck } from './handlers';
+import { handleNodeCheck } from './node-handler';
 
 if (require.main === module) {
   handleNodeCheck().catch(err => {

--- a/src/node-handler.ts
+++ b/src/node-handler.ts
@@ -1,0 +1,66 @@
+import * as debug from 'debug';
+import * as semver from 'semver';
+
+import { MAIN_BRANCH, REPOS, ROLL_TARGETS } from './constants';
+import { getOctokit } from './utils/octokit';
+import { roll } from './utils/roll';
+
+export async function handleNodeCheck(): Promise<void> {
+  const d = debug('roller/node:handleNodeCheck()');
+  const github = await getOctokit();
+
+  d('Fetching nodejs/node releases');
+  const { data: releases } = await github.repos.listReleases({
+    owner: REPOS.node.owner,
+    repo: REPOS.node.repo,
+  });
+  const releaseTags = releases.map(r => r.tag_name);
+
+  d(`Fetching ${MAIN_BRANCH} branch from electron/electron`);
+  const { data: mainBranch } = await github.repos.getBranch({
+    ...REPOS.electron,
+    branch: MAIN_BRANCH,
+  });
+
+  d(`Fetching DEPS for branch ${mainBranch.name} in electron/electron`);
+  const { data: depsData } = await github.repos.getContent({
+    owner: REPOS.electron.owner,
+    repo: REPOS.electron.repo,
+    path: 'DEPS',
+    ref: MAIN_BRANCH,
+  });
+
+  if (!('content' in depsData)) {
+    d(`Error - incorrectly got array when fetching DEPS content for ${MAIN_BRANCH}`);
+    throw new Error(`Upgrade check failed - see logs for more details`);
+  }
+
+  const deps = Buffer.from(depsData.content, 'base64').toString('utf8');
+
+  // find node version from DEPS
+  const versionRegex = new RegExp(`${ROLL_TARGETS.node.depsKey}':\n +'(.+?)',`, 'm');
+  const [, depsNodeVersion] = versionRegex.exec(deps);
+  const majorVersion = semver.major(semver.clean(depsNodeVersion));
+
+  d(`Computing latest upstream version for Node ${majorVersion}`);
+  const latestUpstreamVersion = semver.maxSatisfying(releaseTags, `^${majorVersion}`);
+
+  // Only roll for LTS release lines of Node.js (even-numbered major versions).
+  if (majorVersion % 2 === 0 && semver.gt(latestUpstreamVersion, depsNodeVersion)) {
+    d(
+      `Upgrade possible: ${mainBranch.name} can roll from ${depsNodeVersion} to ${latestUpstreamVersion}`,
+    );
+    try {
+      await roll({
+        rollTarget: ROLL_TARGETS.node,
+        electronBranch: mainBranch,
+        targetVersion: latestUpstreamVersion,
+      });
+    } catch (e) {
+      d(`Error rolling ${mainBranch.name} to ${latestUpstreamVersion}`, e);
+      throw new Error(`Upgrade check failed - see logs for more details`);
+    }
+  } else {
+    d(`No upgrade found - ${depsNodeVersion} is the most recent known in its release line.`);
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,3 +2,4 @@ import { RestEndpointMethodTypes } from '@octokit/rest';
 
 export type PullsListResponseItem = RestEndpointMethodTypes['pulls']['list']['response']['data'][0];
 export type ReposListBranchesResponseItem = RestEndpointMethodTypes['repos']['listBranches']['response']['data'][0];
+export type ReposGetBranchResponseItem = RestEndpointMethodTypes['repos']['getBranch']['response']['data'];

--- a/src/utils/get-supported-branches.ts
+++ b/src/utils/get-supported-branches.ts
@@ -1,0 +1,29 @@
+import { NUM_SUPPORTED_VERSIONS } from '../constants';
+
+// Get array of currently supported branches
+export function getSupportedBranches(branches: { name: string }[]): string[] {
+  const releaseBranches = branches
+    .filter(branch => {
+      const releasePattern = /^(\d)+-(?:(?:[0-9]+-x$)|(?:x+-y$))$/;
+      return releasePattern.test(branch.name);
+    })
+    .map(b => b.name);
+
+  const filtered: Record<string, string> = {};
+  releaseBranches
+    .sort((a, b) => {
+      const aParts = a.split('-');
+      const bParts = b.split('-');
+      for (let i = 0; i < aParts.length; i += 1) {
+        if (aParts[i] === bParts[i]) continue;
+        return parseInt(aParts[i], 10) - parseInt(bParts[i], 10);
+      }
+      return 0;
+    })
+    .forEach(branch => {
+      return (filtered[branch.split('-')[0]] = branch);
+    });
+
+  const values = Object.values(filtered);
+  return values.sort((a, b) => parseInt(a, 10) - parseInt(b, 10)).slice(-NUM_SUPPORTED_VERSIONS);
+}

--- a/tests/handlers-spec.ts
+++ b/tests/handlers-spec.ts
@@ -1,5 +1,7 @@
 import { MAIN_BRANCH, REPOS, ROLL_TARGETS } from '../src/constants';
-import { handleChromiumCheck, handleNodeCheck, getSupportedBranches } from '../src/handlers';
+import { getSupportedBranches } from '../src/utils/get-supported-branches';
+import { handleNodeCheck } from '../src/node-handler';
+import { handleChromiumCheck } from '../src/chromium-handler';
 import { getChromiumReleases } from '../src/utils/get-chromium-tags';
 import { getOctokit } from '../src/utils/octokit';
 import { roll } from '../src/utils/roll';
@@ -154,6 +156,15 @@ describe('handleChromiumCheck()', () => {
           rollTarget: ROLL_TARGETS.chromium,
           targetVersion: '1.2.0.0',
         }),
+      );
+    });
+
+    it('fails if an invalid target is passed', async () => {
+      mockOctokit.repos.getBranch.mockReturnValue(null);
+
+      const invalid = 'i-am-not-a-valid-release-branch';
+      expect(handleChromiumCheck(invalid)).rejects.toThrow(
+        'One or more upgrade checks failed - see logs for more details',
       );
     });
 


### PR DESCRIPTION
It's sometimes the case that the roll assignee will want to force a roll, but not necessarily roll every single possible branch at once. This enables them to pass, for example: `/roll main` or `/roll 25-x-y` and only update a specific branch.