### PR TITLE
refactor: use roll comment for branch

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -27,8 +27,6 @@ export const ROLL_TARGETS = {
 export const BACKPORT_CHECK_SKIP = 'backport-check-skip';
 export const NO_BACKPORT = 'no-backport';
 
-export const ROLLER_CMD_PREFIX = '/roll';
-
 export interface Commit {
   sha: string;
   message: string;


### PR DESCRIPTION
There's no need to fetch the whole PR for the branch name when we can get it from the comment.