### PR TITLE
chore: add private to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "roller",
   "version": "1.0.0",
+  "private": true,
   "description": "automate the submodule update process",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Historically we've added `private` to any `package.json` we don't intend to publish. Add it here for consistency, and to make future scripts easier, like a script which audits repos for missing CFA setup or missing npm badge on the README.