### PR TITLE
refactor: remove unused method getAppOctokit()

### DIFF
--- a/src/utils/octokit.ts
+++ b/src/utils/octokit.ts
@@ -17,15 +17,6 @@ const getAuthProvider = () =>
     clientSecret: process.env.CLIENT_SECRET,
   });
 
-export async function getAppOctokit(): Promise<GitHub> {
-  appOctokit =
-    appOctokit ||
-    new GitHub({
-      auth: ((await getAuthProvider()({ type: 'app' })) as AppAuthentication).token,
-    });
-  return appOctokit;
-}
-
 /**
  * Returns an authenticated Octokit.
  *


### PR DESCRIPTION
Spotted this while looking at the code today trying to figure out why https://github.com/electron/electron/pull/40484 got closed.

Looks like `getAppOctokit()` is an unused method, so this PR removes it