### PR TITLE
chore: check for latest tag if latest release cannot be found

### DIFF
--- a/src/utils/roll-orb.ts
+++ b/src/utils/roll-orb.ts
@@ -145,6 +145,11 @@ export async function rollOrb(
 
   function getTargetKeyAndPreviousVersion(yaml) {
     const curr = yaml[ORB_KEY];
+
+    if (!curr) {
+      d(`No orbs found in .circleci/config.yml - skipping.`);
+      return null;
+    }
     // attempt to find the orb in .circleci/config.yml whos value includes `orbTarget.name`
     const targetKey: string = Object.entries(curr as string).find(([_, value]) =>
       value.startsWith(`${orbTarget.name}@`),


### PR DESCRIPTION
some node orb repos may not have a valid release, but have tags. This PR adds a backup code path that should get a list of repository tags, filter the ones that are semver compliant and get the latest satisfying tag.