### PR TITLE
fix: await promise

### DIFF
--- a/src/utils/roll-orb.ts
+++ b/src/utils/roll-orb.ts
@@ -70,7 +70,7 @@ export async function rollOrb(
       }
 
       d(`updating orb version to ${targetOrbVersion}`);
-      updateConfigFile(orbTarget, targetOrbVersion, updateConfigParams);
+      await updateConfigFile(orbTarget, targetOrbVersion, updateConfigParams);
 
       d(`orb version changed - updating PR body`);
       const re = new RegExp('^Original-Version: (\\S+)', 'm');


### PR DESCRIPTION
When rolling an orb with an existing PR, await this promise, otherwise errors won't be properly handled if the content cannot be updated.