### PR TITLE
chore: lazily create ref when rolling orb

### DIFF
--- a/tests/utils/roll-orb-spec.ts
+++ b/tests/utils/roll-orb-spec.ts
@@ -146,7 +146,7 @@ describe('rollOrb()', () => {
     expect(mockOctokit.repos.getContent).toHaveBeenCalledWith({
       owner: repository.owner,
       repo: repository.repo,
-      ref: `roller/orb/${orbTarget.name}/${branch.name}`,
+      ref: undefined,
       path: '.circleci/config.yml',
     });
 


### PR DESCRIPTION
Reverts #101. I believe the underlying issue was misunderstood in that change - the error was because the CircleCI config content was being fetched from the ref, so if it hadn't been created, that would fail. In the case of no PR existing, just get the config content from the default branch, and then determine if the roll needs to continue, creating the ref at that point.