### PR TITLE
fix: Node.js should only roll on non-security stable lines

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -14,8 +14,6 @@ export const REPO_OWNER = 'electron';
 
 export const MAIN_BRANCH = 'main';
 
-export const NUM_SUPPORTED_VERSIONS = 4;
-
 export const ROLL_TARGETS = {
   node: {
     name: 'node',

--- a/src/node-handler.ts
+++ b/src/node-handler.ts
@@ -19,7 +19,7 @@ export async function handleNodeCheck(): Promise<void> {
   );
   let failed = false;
 
-  const supported = getSupportedBranches(branches);
+  const supported = getSupportedBranches(branches, 3);
   const releaseBranches = branches.filter(branch => supported.includes(branch.name));
   d(`Found ${releaseBranches.length} release branches`);
 

--- a/src/utils/get-supported-branches.ts
+++ b/src/utils/get-supported-branches.ts
@@ -1,7 +1,8 @@
-import { NUM_SUPPORTED_VERSIONS } from '../constants';
-
 // Get array of currently supported branches
-export function getSupportedBranches(branches: { name: string }[]): string[] {
+export function getSupportedBranches(
+  branches: { name: string }[],
+  numSupportedVersions = 4,
+): string[] {
   const releaseBranches = branches
     .filter(branch => {
       const releasePattern = /^(\d)+-(?:(?:[0-9]+-x$)|(?:x+-y$))$/;
@@ -25,5 +26,5 @@ export function getSupportedBranches(branches: { name: string }[]): string[] {
     });
 
   const values = Object.values(filtered);
-  return values.sort((a, b) => parseInt(a, 10) - parseInt(b, 10)).slice(-NUM_SUPPORTED_VERSIONS);
+  return values.sort((a, b) => parseInt(a, 10) - parseInt(b, 10)).slice(-numSupportedVersions);
 }


### PR DESCRIPTION
Follows https://github.com/electron/roller/pull/111

Oldest supported release line is security-only and shouldn't receive Node.js bumps.