### PR TITLE
fix: scope main roll to active LTS

### DIFF
--- a/src/utils/get-nodejs-lts.ts
+++ b/src/utils/get-nodejs-lts.ts
@@ -1,0 +1,37 @@
+import * as semver from 'semver';
+
+const NODE_SCHEDULE_URL = 'https://github.com/nodejs/Release/blob/main/schedule.json';
+
+interface NodeMajorLine {
+  start: string;
+  lts?: string;
+  maintenance?: string;
+  end: string;
+  codeName?: string;
+}
+
+// Returns the latest major version of Node.js that's in active LTS.
+export async function getLatestLTSVersion(): Promise<string | null> {
+  let data: Record<string, NodeMajorLine>;
+  try {
+    const response = await fetch(NODE_SCHEDULE_URL);
+    data = await response.json();
+  } catch (error) {
+    console.error('Failed to fetch Node.js release schedule:', error);
+    return null;
+  }
+
+  const latestLTSVersion = Object.entries(data)
+    .filter(([, { lts }]) => lts && new Date(lts) < new Date())
+    .reduce(
+      (latest, [version, { lts }]) => {
+        if (!latest.lts || new Date(lts) > new Date(latest.lts)) {
+          return { version, lts };
+        }
+        return latest;
+      },
+      { version: null, lts: null },
+    );
+
+  return semver.valid(semver.coerce(latestLTSVersion.version));
+}

--- a/tests/handlers-spec.ts
+++ b/tests/handlers-spec.ts
@@ -7,10 +7,12 @@ import { handleChromiumCheck } from '../src/chromium-handler';
 import { getChromiumReleases } from '../src/utils/get-chromium-tags';
 import { getOctokit } from '../src/utils/octokit';
 import { roll } from '../src/utils/roll';
+import { getLatestLTSVersion } from '../src/utils/get-nodejs-lts';
 
 jest.mock('../src/utils/get-chromium-tags');
 jest.mock('../src/utils/octokit');
 jest.mock('../src/utils/roll');
+jest.mock('../src/utils/get-nodejs-lts');
 
 describe('handleChromiumCheck()', () => {
   let mockOctokit: any;
@@ -373,6 +375,8 @@ describe('handleNodeCheck()', () => {
   });
 
   it('rolls even major versions of Node.js with latest minor/patch update', async () => {
+    (getLatestLTSVersion as jest.Mock).mockReturnValue('14.0.0');
+
     mockOctokit.paginate.mockReturnValue([
       {
         name: '4-x-y',
@@ -416,6 +420,8 @@ describe('handleNodeCheck()', () => {
   });
 
   it('does not roll for uneven major versions of Node.js', async () => {
+    (getLatestLTSVersion as jest.Mock).mockReturnValue('12.0.0');
+
     mockOctokit.repos.getContent.mockReturnValue({
       data: {
         content: Buffer.from(`${ROLL_TARGETS.node.depsKey}':\n    'v11.0.0',`),
@@ -428,6 +434,8 @@ describe('handleNodeCheck()', () => {
   });
 
   it('does not roll if no newer release found', async () => {
+    (getLatestLTSVersion as jest.Mock).mockReturnValue('12.0.0');
+
     mockOctokit.repos.getContent.mockReturnValue({
       data: {
         content: Buffer.from(`${ROLL_TARGETS.node.depsKey}':\n    'v12.2.0',`),
@@ -440,6 +448,8 @@ describe('handleNodeCheck()', () => {
   });
 
   it('throws error if roll() process failed', async () => {
+    (getLatestLTSVersion as jest.Mock).mockReturnValue('14.0.0');
+
     mockOctokit.repos.getContent.mockReturnValue({
       data: {
         content: Buffer.from(`${ROLL_TARGETS.node.depsKey}':\n    'v12.0.0',`),


### PR DESCRIPTION
Follow up to https://github.com/electron/roller/pull/111

Use https://github.com/nodejs/Release/blob/main/schedule.json to determine current active LTS, and allow rolling to a new major version once it becomes active LTS.