### PR TITLE
fix: correctly label Node.js version bump semver

### DIFF
--- a/src/utils/label-utils.ts
+++ b/src/utils/label-utils.ts
@@ -1,0 +1,66 @@
+import { Octokit } from '@octokit/rest';
+import { REPOS } from '../constants';
+
+export const addLabels = async (
+  octokit: Octokit,
+  data: {
+    prNumber: number;
+    labels: string[];
+  },
+) => {
+  // If the PR already has the label, don't try to add it.
+  const labels = data.labels.filter(async label => {
+    const labelExists = await labelExistsOnPR(octokit, {
+      prNumber: data.prNumber,
+      name: label,
+    });
+    return !labelExists;
+  });
+
+  if (labels.length === 0) return;
+
+  await octokit.issues.addLabels({
+    owner: REPOS.electron.owner,
+    repo: REPOS.electron.repo,
+    issue_number: data.prNumber,
+    labels,
+  });
+};
+
+export const removeLabel = async (
+  octokit: Octokit,
+  data: {
+    prNumber: number;
+    name: string;
+  },
+) => {
+  // If the issue does not have the label, don't try remove it.
+  const labelExists = await labelExistsOnPR(octokit, data);
+  if (labelExists) {
+    await octokit.issues.removeLabel({
+      owner: REPOS.electron.owner,
+      repo: REPOS.electron.repo,
+      issue_number: data.prNumber,
+      name: data.name,
+    });
+  }
+};
+
+export const labelExistsOnPR = async (
+  octokit: Octokit,
+  data: {
+    prNumber: number;
+    name: string;
+  },
+) => {
+  const { data: labelData } = await octokit.issues.listLabelsOnIssue({
+    owner: REPOS.electron.owner,
+    repo: REPOS.electron.repo,
+    issue_number: data.prNumber,
+    per_page: 100,
+    page: 1,
+  });
+
+  const labels = labelData.map(l => l.name);
+  return labels.some(label => label === data.name);
+};

--- a/src/utils/octokit.ts
+++ b/src/utils/octokit.ts
@@ -1,12 +1,7 @@
 import { Octokit as GitHub } from '@octokit/rest';
-import {
-  AppAuthentication,
-  createAppAuth,
-  InstallationAccessTokenAuthentication,
-} from '@octokit/auth-app';
+import { createAppAuth, InstallationAccessTokenAuthentication } from '@octokit/auth-app';
 
 let octokit: GitHub;
-let appOctokit: GitHub;
 
 const getAuthProvider = () =>
   createAppAuth({

--- a/tests/utils/roll-spec.ts
+++ b/tests/utils/roll-spec.ts
@@ -40,6 +40,7 @@ describe('roll()', () => {
       },
       issues: {
         addLabels: jest.fn(),
+        listLabelsOnIssue: jest.fn().mockReturnValue({ data: [] }),
       },
     };
     (getOctokit as jest.Mock).mockReturnValue(mockOctokit);


### PR DESCRIPTION
Tie-in work to roll Node.js more regularly in existing release lines. Unlike Chromium, we can distinguish between patch and minor bumps in Chromium, and adjust the semver label accordingly.