### PR TITLE
ci: bump actions/cache to non-deprecated version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,8 @@ on:
   pull_request:
     branches:
       - main
+  schedule:
+    - cron: '0 22 * * 3'
 
 permissions:
   contents: read
@@ -25,7 +27,7 @@ jobs:
         node-version: lts/-1
     - name: Cache node_modules
       id: cache-node-modules
-      uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a  # tag: v4.1.2
+      uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57  # tag: v4.2.0
       with:
         path: node_modules
         key: ${{ runner.os }}-${{ hashFiles('yarn.lock') }}-node-modules


### PR DESCRIPTION
Also schedules CI to run on a regular schedule so we can spot failures sooner (or in this case the deprecation warning). This is now standard practice on our repos.