### PR TITLE
fix: don't hold on to raw auth tokens

### DIFF
--- a/src/utils/octokit.ts
+++ b/src/utils/octokit.ts
@@ -3,15 +3,6 @@ import { createAppAuth, InstallationAccessTokenAuthentication } from '@octokit/a
 
 let octokit: GitHub;
 
-const getAuthProvider = () =>
-  createAppAuth({
-    appId: process.env.APP_ID,
-    privateKey: process.env.PRIVATE_KEY,
-    installationId: process.env.INSTALLATION_ID,
-    clientId: process.env.CLIENT_ID,
-    clientSecret: process.env.CLIENT_SECRET,
-  });
-
 /**
  * Returns an authenticated Octokit.
  *
@@ -21,11 +12,14 @@ export async function getOctokit(): Promise<GitHub> {
   octokit =
     octokit ||
     new GitHub({
-      auth: (
-        (await getAuthProvider()({
-          type: 'installation',
-        })) as InstallationAccessTokenAuthentication
-      ).token,
+      authStrategy: createAppAuth,
+      auth: {
+        appId: process.env.APP_ID,
+        privateKey: process.env.PRIVATE_KEY,
+        installationId: process.env.INSTALLATION_ID,
+        clientId: process.env.CLIENT_ID,
+        clientSecret: process.env.CLIENT_SECRET,
+      },
     });
 
   return octokit;


### PR DESCRIPTION
The current implementation is getting an installation auth token and then holding on to it indefinitely, which is a problem because those expire after 60 minutes. Refactor to use the proper approach to let Octokit fetch new tokens as needed.