### PR TITLE
fix: github actions runner roller for linux

### DIFF
--- a/src/actions-runner-handler.ts
+++ b/src/actions-runner-handler.ts
@@ -46,8 +46,8 @@ export async function rollActionsRunner() {
     const currentImages = currentLinuxImages(runnerFile.raw);
     if (currentImages.amd64 !== archDigests.amd64 || currentImages.arm64 !== archDigests.arm64) {
       d(`Current linux images in "${arcEnv}" are outdated, updating to ${latestVersion}.`);
-      let newContent = runnerFile.raw.replace(currentImages.amd64, archDigests.amd64);
-      newContent = newContent.replace(currentImages.arm64, archDigests.arm64);
+      let newContent = runnerFile.raw.replaceAll(currentImages.amd64, archDigests.amd64);
+      newContent = newContent.replaceAll(currentImages.arm64, archDigests.arm64);
       await rollInfra(
         `${arcEnv}/actions-runner`,
         'github actions runner images',

--- a/src/utils/arc-image.ts
+++ b/src/utils/arc-image.ts
@@ -6,7 +6,7 @@ const WINDOWS_RUNNER_REGEX = /ARG RUNNER_VERSION=([\d.]+)/;
 const WINDOWS_IMAGE_REGEX =
   /electronarc\.azurecr\.io\/win-actions-runner:main-[a-f0-9]{7}@sha256:[a-f0-9]{64}/;
 const LINUX_IMAGE_REGEX =
-  /if eq .cpuArch "amd64".*\n.*image: (ghcr.io\/actions\/actions-runner:[0-9]+\.[0-9]+\.[0-9]+@sha256:[a-f0-9]{64}).*\n.*{{- else }}.*\n.*image: (ghcr.io\/actions\/actions-runner:[0-9]+\.[0-9]+\.[0-9]+@sha256:[a-f0-9]{64})/;
+  /if eq .cpuArch "amd64".*\n.*image: ghcr.io\/actions\/actions-runner:([0-9]+\.[0-9]+\.[0-9]+@sha256:[a-f0-9]{64}).*\n.*{{- else }}.*\n.*image: ghcr.io\/actions\/actions-runner:([0-9]+\.[0-9]+\.[0-9]+@sha256:[a-f0-9]{64})/;
 
 export async function getFileContent(octokit: Octokit, filePath: string, ref = MAIN_BRANCH) {
   const { data } = await octokit.repos.getContent({

--- a/src/utils/get-latest-runner-images.ts
+++ b/src/utils/get-latest-runner-images.ts
@@ -84,7 +84,7 @@ export async function getLatestRunnerImages(
       platform?.os === 'linux' &&
       (platform.architecture === 'amd64' || platform.architecture === 'arm64')
     ) {
-      archDigests[platform.architecture] = manifest.digest;
+      archDigests[platform.architecture] = `${tagVersion}@${manifest.digest}`;
     }
   }
 

--- a/tests/actions-runner-handler.test.ts
+++ b/tests/actions-runner-handler.test.ts
@@ -19,21 +19,40 @@ const mockFileContent = (raw: string) => ({ raw, sha: 'sha' });
 
 const latestVersion = '2.325.0';
 const archDigests = {
-  amd64: 'sha256:amd64digest',
-  arm64: 'sha256:arm64digest',
+  amd64: '2.325.0@sha256:amd64digest',
+  arm64: '2.325.0@sha256:arm64digest',
 };
 
 const newWinDockerFile = 'ARG RUNNER_VERSION=2.325.0';
 const oldWinDockerFile = 'ARG RUNNER_VERSION=2.324.0';
 
 const oldLinuxImages = {
-  amd64: 'ghcr.io/actions/actions-runner:2.324.0@sha256:oldamd64',
-  arm64: 'ghcr.io/actions/actions-runner:2.324.0@sha256:oldarm64',
+  amd64: '2.324.0@sha256:oldamd64',
+  arm64: '2.324.0@sha256:oldarm64',
 };
 const newLinuxImages = {
   amd64: archDigests.amd64,
   arm64: archDigests.arm64,
 };
+
+function generateFileContent(images) {
+  return `
+    {{- if eq .cpuArch "amd64" }}
+    image: ghcr.io/actions/actions-runner:${images.amd64}
+    {{- else }}
+    image: ghcr.io/actions/actions-runner:${images.arm64}
+    {{- end }}
+    {{ more content here }}
+    {{- if eq .cpuArch "amd64" }}
+    image: ghcr.io/actions/actions-runner:${images.amd64}
+    {{- else }}
+    image: ghcr.io/actions/actions-runner:${images.arm64}
+    {{- end }}
+    `;
+}
+
+const oldLinuxFileContent = generateFileContent(oldLinuxImages);
+const newLinuxFileContent = generateFileContent(newLinuxImages);
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -45,7 +64,7 @@ beforeEach(() => {
   vi.mocked(arcImage.getFileContent).mockImplementation(async (_octokit: any, file: string) => {
     if (file === constants.WINDOWS_DOCKER_FILE) return mockFileContent(oldWinDockerFile);
     if (file === constants.ARC_RUNNER_ENVIRONMENTS.prod)
-      return mockFileContent(`amd64: ${oldLinuxImages.amd64}\narm64: ${oldLinuxImages.arm64}`);
+      return mockFileContent(generateFileContent(oldLinuxImages));
     return mockFileContent('');
   });
   vi.mocked(arcImage.getCurrentWindowsRunnerVersion).mockImplementation(
@@ -59,25 +78,61 @@ beforeEach(() => {
 });
 
 describe('rollActionsRunner', () => {
-  it('should update windows runner if version is outdated', async () => {
+  it('should update both linx and windows if version is outdated', async () => {
     await rollActionsRunner();
+    expect(rollInfraModule.rollInfra).toHaveBeenCalledTimes(2);
+    expect(rollInfraModule.rollInfra).toHaveBeenNthCalledWith(
+      1,
+      'prod/actions-runner',
+      'github actions runner images',
+      latestVersion,
+      constants.WINDOWS_DOCKER_FILE,
+      newWinDockerFile,
+    );
+    expect(rollInfraModule.rollInfra).toHaveBeenNthCalledWith(
+      2,
+      'prod/actions-runner',
+      'github actions runner images',
+      latestVersion,
+      constants.ARC_RUNNER_ENVIRONMENTS.prod,
+      newLinuxFileContent,
+    );
+  });
+
+  it('should update windows runner if version is outdated', async () => {
+    vi.mocked(arcImage.getFileContent).mockImplementation(async (_octokit: any, file: string) => {
+      if (file === constants.WINDOWS_DOCKER_FILE) return mockFileContent(oldWinDockerFile);
+      if (file === constants.ARC_RUNNER_ENVIRONMENTS.prod)
+        return mockFileContent(newLinuxFileContent);
+      return mockFileContent('');
+    });
+    await rollActionsRunner();
+    expect(rollInfraModule.rollInfra).toHaveBeenCalledTimes(1);
     expect(rollInfraModule.rollInfra).toHaveBeenCalledWith(
       'prod/actions-runner',
       'github actions runner images',
       latestVersion,
       constants.WINDOWS_DOCKER_FILE,
-      expect.stringContaining(latestVersion),
+      newWinDockerFile,
     );
   });
 
   it('should update linux images if digests are outdated', async () => {
+    vi.mocked(arcImage.getFileContent).mockImplementation(async (_octokit: any, file: string) => {
+      if (file === constants.WINDOWS_DOCKER_FILE) return mockFileContent(newWinDockerFile);
+      if (file === constants.ARC_RUNNER_ENVIRONMENTS.prod)
+        return mockFileContent(oldLinuxFileContent);
+      return mockFileContent('');
+    });
+
     await rollActionsRunner();
+    expect(rollInfraModule.rollInfra).toHaveBeenCalledTimes(1);
     expect(rollInfraModule.rollInfra).toHaveBeenCalledWith(
       'prod/actions-runner',
       'github actions runner images',
       latestVersion,
       constants.ARC_RUNNER_ENVIRONMENTS.prod,
-      expect.any(String),
+      newLinuxFileContent,
     );
   });
 
@@ -85,7 +140,7 @@ describe('rollActionsRunner', () => {
     vi.mocked(arcImage.getFileContent).mockImplementation(async (_octokit: any, file: string) => {
       if (file === constants.WINDOWS_DOCKER_FILE) return mockFileContent(newWinDockerFile);
       if (file === constants.ARC_RUNNER_ENVIRONMENTS.prod)
-        return mockFileContent(`amd64: ${archDigests.amd64}\narm64: ${archDigests.arm64}`);
+        return mockFileContent(newLinuxFileContent);
       return mockFileContent('');
     });
     vi.mocked(arcImage.getCurrentWindowsRunnerVersion).mockImplementation(

--- a/tests/utils/arc-image.test.ts
+++ b/tests/utils/arc-image.test.ts
@@ -39,10 +39,10 @@ describe('arc-image utils', () => {
   it('should extract both linux images', () => {
     const images = currentLinuxImages(linuxImageContent);
     expect(images.amd64).toBe(
-      'ghcr.io/actions/actions-runner:2.325.0@sha256:b865e3f046f0a92a4b936ae75c5bc5615b99b64eb4801b0e5220f13f8867d6b8',
+      '2.325.0@sha256:b865e3f046f0a92a4b936ae75c5bc5615b99b64eb4801b0e5220f13f8867d6b8',
     );
     expect(images.arm64).toBe(
-      'ghcr.io/actions/actions-runner:2.325.0@sha256:ab3fb968f7bcc8b34677b93a98f576142a2affde57ea2e7b461f515fd8a12453',
+      '2.325.0@sha256:ab3fb968f7bcc8b34677b93a98f576142a2affde57ea2e7b461f515fd8a12453',
     );
   });
 

--- a/tests/utils/get-latest-runner-images.test.ts
+++ b/tests/utils/get-latest-runner-images.test.ts
@@ -42,8 +42,8 @@ describe('getLatestRunnerImages', () => {
     const result = await getLatestRunnerImages(mockOctokit);
     expect(result).toEqual({
       archDigests: {
-        amd64: 'sha256:amd64digest',
-        arm64: 'sha256:arm64digest',
+        amd64: '2.325.0@sha256:amd64digest',
+        arm64: '2.325.0@sha256:arm64digest',
       },
       latestVersion: '2.325.0',
     });


### PR DESCRIPTION
- Followup to #147.
When the GitHub Actions runner roller ran, it accidentally tried to update the linux containers as follows:
FROM:
```
image: ghcr.io/actions/actions-runner:2.325.0@sha256:b865e3f046f0a92a4b936ae75c5bc5615b99b64eb4801b0e5220f13f8867d6b8
```
TO:
```
image: sha256:b865e3f046f0a92a4b936ae75c5bc5615b99b64eb4801b0e5220f13f8867d6b8 
```

This PR fixes that issue and also updates the tests to better verify the GitHub Actions roller.