### PR TITLE
build: update ts target to es2021 to get string.replaceAll

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,5 +36,7 @@ jobs:
       run: yarn --frozen-lockfile
     - name: Lint
       run: yarn lint
+    - name: Build
+      run: yarn build
     - name: Test
       run: yarn test

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
 	"compilerOptions": {
 		"module": "commonjs",
-		"target": "es2020",
+		"target": "es2021",
 		"outDir": "lib",
 		"sourceMap": true,
 		"rootDir": "src",


### PR DESCRIPTION
- Fixes the following error introduced in #148
```
       src/actions-runner-handler.ts(49,39): error TS2550: Property 'replaceAll' does not exist on type 'string'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2021' or later.
```
