### PR TITLE
chore: update windows-image-roller for new arc cluster

### DIFF
--- a/src/utils/arc-image.ts
+++ b/src/utils/arc-image.ts
@@ -4,7 +4,7 @@ import { getOctokit } from './octokit';
 
 const WINDOWS_RUNNER_REGEX = /ARG RUNNER_VERSION=([\d.]+)/;
 const WINDOWS_IMAGE_REGEX =
-  /electronarc\.azurecr\.io\/win-actions-runner:main-[a-f0-9]{7}@sha256:[a-f0-9]{64}/;
+  /\$\{registry_name\}\.azurecr\.io\/win-actions-runner:main-[a-f0-9]{7}@sha256:[a-f0-9]{64}/;
 const LINUX_IMAGE_REGEX =
   /if eq .cpuArch "amd64".*\n.*image: ghcr.io\/actions\/actions-runner:([0-9]+\.[0-9]+\.[0-9]+@sha256:[a-f0-9]{64}).*\n.*{{- else }}.*\n.*image: ghcr.io\/actions\/actions-runner:([0-9]+\.[0-9]+\.[0-9]+@sha256:[a-f0-9]{64})/;
 

--- a/src/windows-image-handler.ts
+++ b/src/windows-image-handler.ts
@@ -39,7 +39,10 @@ async function getLatestVersionOfImage() {
       bestMainTag = mainTag;
     }
   }
-  return [`electronarc.azurecr.io/win-actions-runner:${bestMainTag}@${best.name}`, bestMainTag];
+  return [
+    `\${registry_name}.azurecr.io/win-actions-runner:${bestMainTag}@${best.name}`,
+    bestMainTag,
+  ];
 }
 
 const WINDOWS_IMAGE_DOCKERFILE_PATH = 'docker/windows-actions-runner/Dockerfile';

--- a/tests/utils/arc-image.test.ts
+++ b/tests/utils/arc-image.test.ts
@@ -5,7 +5,8 @@ import {
   getCurrentWindowsRunnerVersion,
 } from '../../src/utils/arc-image';
 
-const windowsImageContent = `electronarc.azurecr.io/win-actions-runner:main-abcdef0@sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef`;
+const windowsImageContent =
+  '${registry_name}.azurecr.io/win-actions-runner:main-abcdef0@sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef';
 
 const linuxImageContent = `containers:
                   - name: runner
@@ -32,7 +33,7 @@ const invalidLinuxContent = `{{- if eq .cpuArch "amd64" }}\nimage: something-els
 describe('arc-image utils', () => {
   it('should extract the current Windows image', () => {
     expect(currentWindowsImage(windowsImageContent)).toBe(
-      'electronarc.azurecr.io/win-actions-runner:main-abcdef0@sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
+      '${registry_name}.azurecr.io/win-actions-runner:main-abcdef0@sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
     );
   });
 


### PR DESCRIPTION
Needed as a followup to https://github.com/electron/electron/pull/47897.