### PR TITLE
fix: remove require.main in cron file after ESM migration

### DIFF
--- a/src/actions-runner-cron.ts
+++ b/src/actions-runner-cron.ts
@@ -1,6 +1,9 @@
+import { realpathSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
 import { rollActionsRunner } from './actions-runner-handler.js';
 
-if (require.main === module) {
+if (realpathSync(process.argv[1]) === fileURLToPath(import.meta.url)) {
   rollActionsRunner().catch((err: Error) => {
     console.log('Actions Runner Cron Failed');
     console.error(err);

--- a/src/build-images-chromium-deps-cron.ts
+++ b/src/build-images-chromium-deps-cron.ts
@@ -1,6 +1,9 @@
+import { realpathSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
 import { handleBuildImagesChromiumDepsCheck } from './build-images-chromium-deps-handler.js';
 
-if (require.main === module) {
+if (realpathSync(process.argv[1]) === fileURLToPath(import.meta.url)) {
   handleBuildImagesChromiumDepsCheck().catch((err) => {
     console.log('Build Images Chromium Deps Cron Failed');
     console.error(err);

--- a/src/chromium-cron.ts
+++ b/src/chromium-cron.ts
@@ -1,6 +1,9 @@
+import { realpathSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
 import { handleChromiumCheck } from './chromium-handler.js';
 
-if (require.main === module) {
+if (realpathSync(process.argv[1]) === fileURLToPath(import.meta.url)) {
   handleChromiumCheck().catch((err) => {
     console.log('Chromium Cron Failed');
     console.error(err);

--- a/src/node-cron.ts
+++ b/src/node-cron.ts
@@ -1,6 +1,9 @@
+import { realpathSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
 import { handleNodeCheck } from './node-handler.js';
 
-if (require.main === module) {
+if (realpathSync(process.argv[1]) === fileURLToPath(import.meta.url)) {
   handleNodeCheck().catch((err) => {
     console.log('Node Cron Failed');
     console.error(err);

--- a/src/windows-image-cron.ts
+++ b/src/windows-image-cron.ts
@@ -1,6 +1,9 @@
+import { realpathSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
 import { rollWindowsArcImage } from './windows-image-handler.js';
 
-if (require.main === module) {
+if (realpathSync(process.argv[1]) === fileURLToPath(import.meta.url)) {
   rollWindowsArcImage().catch((err: Error) => {
     console.log('Windows Image Cron Failed');
     console.error(err);


### PR DESCRIPTION
These broke after #187. We might actually be on a version of Node.js which could use `import.meta.main` instead to make it simple, but this is prioritizing getting roller back up and running on its cron jobs, will look into that as a follow-up.