### PR TITLE
feat: trigger electron/agent-workflows chromium-upgrade on Chromium roll

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -21,6 +21,13 @@ export const REPO_OWNER = 'electron';
 
 export const MAIN_BRANCH = 'main';
 
+export const CHROMIUM_UPGRADE_WORKFLOW = {
+  owner: 'electron',
+  repo: 'agent-workflows',
+  workflow_id: 'chromium-upgrade.yml',
+  ref: 'main',
+};
+
 export const ROLL_TARGETS = {
   node: {
     name: 'node',

--- a/src/utils/roll.ts
+++ b/src/utils/roll.ts
@@ -3,6 +3,7 @@ import * as semver from 'semver';
 
 import {
   BACKPORT_CHECK_SKIP,
+  CHROMIUM_UPGRADE_WORKFLOW,
   MAIN_BRANCH,
   NO_BACKPORT,
   REPOS,
@@ -54,6 +55,16 @@ async function updateLabels(
   await addLabels(octokit, { prNumber, labels });
 }
 
+async function triggerChromiumUpgradeWorkflow(octokit: Octokit) {
+  const d = debug('roller/chromium:triggerChromiumUpgradeWorkflow()');
+  try {
+    await octokit.actions.createWorkflowDispatch(CHROMIUM_UPGRADE_WORKFLOW);
+    d(`Dispatched ${CHROMIUM_UPGRADE_WORKFLOW.workflow_id}`);
+  } catch (e) {
+    d(`Failed to dispatch ${CHROMIUM_UPGRADE_WORKFLOW.workflow_id}: ${e.message}`);
+  }
+}
+
 export async function roll({
   rollTarget,
   electronBranch,
@@ -65,6 +76,8 @@ export async function roll({
   d(
     `roll triggered for electron branch=${electronBranch.name} ${rollTarget.depsKey}=${targetVersion}`,
   );
+
+  let didRoll = false;
 
   // Look for a pre-existing PR that targets this branch to see if we can update that.
   const existingPrsForBranch = (await github.paginate('GET /repos/:owner/:repo/pulls', {
@@ -131,6 +144,8 @@ export async function roll({
         previousVersion: prVersionText[1],
         prNumber: pr.number,
       });
+
+      didRoll = true;
     }
   } else {
     d(`No existing PR found - raising a new PR`);
@@ -185,5 +200,11 @@ export async function roll({
     });
 
     d(`New PR: ${newPr.data.html_url}`);
+
+    didRoll = true;
+  }
+
+  if (didRoll && rollTarget === ROLL_TARGETS.chromium && electronBranch.name === MAIN_BRANCH) {
+    await triggerChromiumUpgradeWorkflow(github);
   }
 }

--- a/tests/utils/roll.spec.ts
+++ b/tests/utils/roll.spec.ts
@@ -2,7 +2,12 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { roll } from '../../src/utils/roll.js';
 import { getOctokit } from '../../src/utils/octokit.js';
-import { ROLL_TARGETS, REPOS } from '../../src/constants.js';
+import {
+  CHROMIUM_UPGRADE_WORKFLOW,
+  MAIN_BRANCH,
+  REPOS,
+  ROLL_TARGETS,
+} from '../../src/constants.js';
 import { updateDepsFile } from '../../src/utils/update-deps.js';
 
 vi.mock('../../src/utils/octokit.js');
@@ -43,6 +48,9 @@ describe('roll()', () => {
       issues: {
         addLabels: vi.fn(),
         listLabelsOnIssue: vi.fn().mockReturnValue({ data: [] }),
+      },
+      actions: {
+        createWorkflowDispatch: vi.fn(),
       },
     };
     vi.mocked(getOctokit).mockReturnValue(mockOctokit);
@@ -175,6 +183,89 @@ describe('roll()', () => {
         head: `${REPOS.electron.owner}:${newBranchName}`,
       }),
     );
+  });
+
+  describe('chromium-upgrade workflow dispatch', () => {
+    const mainBranch = { ...branch, name: MAIN_BRANCH };
+
+    it('dispatches when creating a new chromium PR on main', async () => {
+      mockOctokit.paginate.mockReturnValue([]);
+
+      await roll({
+        rollTarget: ROLL_TARGETS.chromium,
+        electronBranch: mainBranch,
+        targetVersion: '120.0.0.0',
+      });
+
+      expect(mockOctokit.actions.createWorkflowDispatch).toHaveBeenCalledTimes(1);
+      expect(mockOctokit.actions.createWorkflowDispatch).toHaveBeenCalledWith(
+        CHROMIUM_UPGRADE_WORKFLOW,
+      );
+    });
+
+    it('dispatches when updating an existing chromium PR on main', async () => {
+      mockOctokit.paginate.mockReturnValue([
+        {
+          user: { login: 'electron-roller[bot]' },
+          title: `chore: bump ${ROLL_TARGETS.chromium.name} to bar`,
+          number: 1,
+          head: { ref: 'asd' },
+          body: 'Original-Version: 119.0.0.0',
+          labels: [],
+          created_at: new Date().toISOString(),
+        },
+      ]);
+
+      await roll({
+        rollTarget: ROLL_TARGETS.chromium,
+        electronBranch: mainBranch,
+        targetVersion: '120.0.0.0',
+      });
+
+      expect(mockOctokit.actions.createWorkflowDispatch).toHaveBeenCalledTimes(1);
+      expect(mockOctokit.actions.createWorkflowDispatch).toHaveBeenCalledWith(
+        CHROMIUM_UPGRADE_WORKFLOW,
+      );
+    });
+
+    it('does not dispatch for node rolls on main', async () => {
+      mockOctokit.paginate.mockReturnValue([]);
+
+      await roll({
+        rollTarget: ROLL_TARGETS.node,
+        electronBranch: mainBranch,
+        targetVersion: 'v10.0.0',
+      });
+
+      expect(mockOctokit.actions.createWorkflowDispatch).not.toHaveBeenCalled();
+    });
+
+    it('does not dispatch for chromium rolls on a release branch', async () => {
+      mockOctokit.paginate.mockReturnValue([]);
+
+      await roll({
+        rollTarget: ROLL_TARGETS.chromium,
+        electronBranch: branch,
+        targetVersion: '120.0.0.0',
+      });
+
+      expect(mockOctokit.actions.createWorkflowDispatch).not.toHaveBeenCalled();
+    });
+
+    it('does not throw when dispatch itself fails', async () => {
+      mockOctokit.paginate.mockReturnValue([]);
+      mockOctokit.actions.createWorkflowDispatch.mockRejectedValueOnce(new Error('boom'));
+
+      await expect(
+        roll({
+          rollTarget: ROLL_TARGETS.chromium,
+          electronBranch: mainBranch,
+          targetVersion: '120.0.0.0',
+        }),
+      ).resolves.toBeUndefined();
+
+      expect(mockOctokit.pulls.create).toHaveBeenCalled();
+    });
   });
 
   it('skips PR if existing one has been paused', async () => {


### PR DESCRIPTION
## What

After a Chromium roll PR is created or updated against `electron/electron` `main`, roller dispatches the `chromium-upgrade.yml` workflow in `electron/agent-workflows` via `octokit.actions.createWorkflowDispatch` (ref `main`, no inputs).

## Why

That workflow runs the Claude chromium-upgrade agent against the `roller/chromium/main` branch — the agent reads the roll state directly from the branch, so no PR number / version needs to be passed through. The workflow's concurrency group (`claude-chromium-upgrade`, `cancel-in-progress: true`) means re-dispatching on every roll update is safe: newer runs cancel older ones.

## Gating

- Chromium target only — Node rolls do not dispatch.
- Main branch only — release-branch chromium rolls do not dispatch.
- Skipped when the roll was a no-op (existing PR loop ran but no `pulls.update` actually fired, e.g. all PRs were trop-bot / paused / DEPS-unchanged).
- Dispatch failures are caught and `debug`-logged so a 403/404 from the Actions API never breaks the roll itself.

## Note for deployment

The roller GitHub App installation needs `actions:write` on `electron/agent-workflows` for `createWorkflowDispatch` to succeed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QyzsC7X5YQB6qbfUdihRoE)_