### PR TITLE
refactor: cleanup common code

### DIFF
--- a/src/build-images-handler.ts
+++ b/src/build-images-handler.ts
@@ -3,6 +3,7 @@ import debug from 'debug';
 import { Octokit } from '@octokit/rest';
 import type { Context } from 'probot';
 
+import { getContent } from './utils/github-utils.js';
 import { getOctokit } from './utils/octokit.js';
 import { MAIN_BRANCH, REPOS } from './constants.js';
 
@@ -17,17 +18,16 @@ const files = [
 ];
 
 export async function shouldUpdateFiles(octokit: Octokit, oid: string) {
-  const { data: file } = await octokit.rest.repos.getContent({
+  const file = await getContent(octokit, {
     ...REPOS.electron,
     path: files[0],
   });
 
-  if (!('content' in file)) {
-    throw new Error(`Incorrectly received array when fetching content for ${files[0]}`);
+  if (file === null) {
+    throw new Error(`Could not fetch content for ${files[0]}`);
   }
 
-  const fileContent = Buffer.from(file.content, 'base64').toString('utf-8');
-  const match = fileContent.match(oid);
+  const match = file.content.match(oid);
   if (match?.[0] === oid) {
     return false;
   }
@@ -72,24 +72,23 @@ export async function updateFilesWithNewOid(
 
   for (const filePath of files) {
     try {
-      const { data: file } = await octokit.rest.repos.getContent({
+      const file = await getContent(octokit, {
         ...REPOS.electron,
         path: filePath,
       });
 
-      if (!('content' in file)) {
-        throw new Error(`Incorrectly received array when fetching content for ${filePath}`);
+      if (file === null) {
+        throw new Error(`Could not fetch content for ${filePath}`);
       }
 
-      const fileContent = Buffer.from(file.content, 'base64').toString('utf-8');
-      const match = fileContent.match(previousOid);
+      const match = file.content.match(previousOid);
       if (!match) {
         d(`No match found for ${filePath}`);
         continue;
       }
 
       d(`Updating ${filePath} from ${match[0]} to ${targetOid}`);
-      const newContent = fileContent.replace(match[0], targetOid);
+      const newContent = file.content.replace(match[0], targetOid);
       await octokit.rest.repos.createOrUpdateFileContents({
         ...REPOS.electron,
         path: filePath,

--- a/src/chromium-handler.ts
+++ b/src/chromium-handler.ts
@@ -4,6 +4,7 @@ import { MAIN_BRANCH, REPOS, ROLL_TARGETS } from './constants.js';
 import { compareChromiumVersions } from './utils/compare-chromium-versions.js';
 import { getChromiumReleases, Release } from './utils/get-chromium-tags.js';
 import { getSupportedBranches } from './utils/get-supported-branches.js';
+import { getContent } from './utils/github-utils.js';
 import { getOctokit } from './utils/octokit.js';
 import { roll } from './utils/roll.js';
 import { ReposGetBranchResponseItem, ReposListBranchesResponseItem } from './types.js';
@@ -15,19 +16,18 @@ async function rollReleaseBranch(github: Octokit, branch: BranchItem) {
   const d = debug(`roller/chromium:rollReleaseBranch('${branch.name}')`);
 
   d(`Fetching DEPS for ${branch.name}`);
-  const { data: depsData } = await github.repos.getContent({
+  const deps = await getContent(github, {
     ...REPOS.electron,
     path: 'DEPS',
     ref: branch.commit.sha,
   });
 
-  if (!('content' in depsData)) {
-    throw new Error(`Incorrectly received array when fetching DEPS content for ${branch.name}`);
+  if (deps === null) {
+    throw new Error(`Could not fetch DEPS content for ${branch.name}`);
   }
 
-  const deps = Buffer.from(depsData.content, 'base64').toString('utf8');
   const versionRegex = new RegExp(`${ROLL_TARGETS.chromium.depsKey}':\n +'(.+?)',`, 'm');
-  const [, chromiumVersion] = versionRegex.exec(deps);
+  const [, chromiumVersion] = versionRegex.exec(deps.content);
 
   const chromiumMajorVersion = Number(chromiumVersion.split('.')[0]);
 
@@ -75,20 +75,19 @@ async function rollMainBranch(github: Octokit) {
   }
 
   d(`Fetching DEPS for ${MAIN_BRANCH}`);
-  const { data: depsData } = await github.repos.getContent({
+  const deps = await getContent(github, {
     owner: REPOS.electron.owner,
     repo: REPOS.electron.repo,
     path: 'DEPS',
     ref: MAIN_BRANCH,
   });
 
-  if (!('content' in depsData)) {
-    throw new Error(`Incorrectly received array when fetching DEPS content for ${MAIN_BRANCH}`);
+  if (deps === null) {
+    throw new Error(`Could not fetch DEPS content for ${MAIN_BRANCH}`);
   }
 
-  const deps = Buffer.from(depsData.content, 'base64').toString('utf8');
   const versionRegex = new RegExp(`${ROLL_TARGETS.chromium.depsKey}':\n +'(.+?)',`, 'm');
-  const [, currentVersion] = versionRegex.exec(deps);
+  const [, currentVersion] = versionRegex.exec(deps.content);
 
   // We should be able to parse major version as a number.
   const chromiumMajorVersion = Number(currentVersion.split('.')[0]);

--- a/src/node-handler.ts
+++ b/src/node-handler.ts
@@ -2,6 +2,7 @@ import debug from 'debug';
 import * as semver from 'semver';
 
 import { MAIN_BRANCH, REPOS, ROLL_TARGETS } from './constants.js';
+import { getContent } from './utils/github-utils.js';
 import { getOctokit } from './utils/octokit.js';
 import { roll } from './utils/roll.js';
 import { ReposListBranchesResponseItem } from './types.js';
@@ -76,23 +77,21 @@ async function rollBranch(branch: string, isMain: boolean): Promise<void> {
   });
 
   d(`Fetching DEPS for branch ${targetBranch.name} in electron/electron`);
-  const { data: depsData } = await github.repos.getContent({
+  const deps = await getContent(github, {
     owner: REPOS.electron.owner,
     repo: REPOS.electron.repo,
     path: 'DEPS',
     ref: branch,
   });
 
-  if (!('content' in depsData)) {
-    d(`Error - incorrectly got array when fetching DEPS content for ${branch}`);
+  if (deps === null) {
+    d(`Error - could not fetch DEPS content for ${branch}`);
     throw new Error(`Upgrade check failed - see logs for more details`);
   }
 
-  const deps = Buffer.from(depsData.content, 'base64').toString('utf8');
-
   // find node version from DEPS
   const versionRegex = new RegExp(`${ROLL_TARGETS.node.depsKey}':\n +'(.+?)',`, 'm');
-  const [, depsNodeVersion] = versionRegex.exec(deps);
+  const [, depsNodeVersion] = versionRegex.exec(deps.content);
   const majorVersion = semver.major(semver.clean(depsNodeVersion));
 
   d(`Computing latest upstream version for Node ${majorVersion}`);

--- a/src/utils/arc-image.ts
+++ b/src/utils/arc-image.ts
@@ -1,5 +1,6 @@
 import { Octokit } from '@octokit/rest';
 import { MAIN_BRANCH, REPOS } from '../constants.js';
+import { getContent } from './github-utils.js';
 import { getOctokit } from './octokit.js';
 
 const WINDOWS_RUNNER_REGEX = /ARG RUNNER_VERSION=([\d.]+)/;
@@ -9,13 +10,13 @@ const LINUX_IMAGE_REGEX =
   /if eq .cpuArch "amd64".*\n.*image: ghcr.io\/actions\/actions-runner:([0-9]+\.[0-9]+\.[0-9]+@sha256:[a-f0-9]{64}).*\n.*{{- else }}.*\n.*image: ghcr.io\/actions\/actions-runner:([0-9]+\.[0-9]+\.[0-9]+@sha256:[a-f0-9]{64})/;
 
 export async function getFileContent(octokit: Octokit, filePath: string, ref = MAIN_BRANCH) {
-  const { data } = await octokit.repos.getContent({
+  const data = await getContent(octokit, {
     ...REPOS.electronInfra,
     path: filePath,
     ref,
   });
-  if ('content' in data) {
-    return { raw: Buffer.from(data.content, 'base64').toString('utf8'), sha: data.sha };
+  if (data !== null) {
+    return { raw: data.content, sha: data.sha };
   }
   throw 'wat';
 }

--- a/src/utils/chromium-gitiles.ts
+++ b/src/utils/chromium-gitiles.ts
@@ -1,4 +1,28 @@
-const CHROMIUM_GITILES_BASE = 'https://chromium.googlesource.com/chromium/src';
+export const CHROMIUM_GITILES_BASE = 'https://chromium.googlesource.com/chromium/src';
+
+export interface ChromiumCommit {
+  commit: string;
+  tree: string;
+  parents: string[];
+  author: {
+    name: string;
+    email: string;
+    time: string;
+  };
+  committer: {
+    name: string;
+    email: string;
+    time: string;
+  };
+  message: string;
+}
+
+/**
+ * Parse a Gitiles JSON response, stripping the )]}' security prefix.
+ */
+function parseGitilesJSON(text: string) {
+  return JSON.parse(text.slice(text.indexOf('{')));
+}
 
 /**
  * Get the current HEAD SHA from Chromium main branch
@@ -6,8 +30,7 @@ const CHROMIUM_GITILES_BASE = 'https://chromium.googlesource.com/chromium/src';
 export async function getChromiumHeadSha(): Promise<string> {
   const response = await fetch(`${CHROMIUM_GITILES_BASE}/+/refs/heads/main?format=JSON`);
   const text = await response.text();
-  // Gitiles returns JSON with )]}' prefix for security
-  const data = JSON.parse(text.slice(text.indexOf('{')));
+  const data = parseGitilesJSON(text);
   return data.commit;
 }
 
@@ -41,4 +64,17 @@ export async function didChromiumFilesChange(
   }
 
   return false;
+}
+
+export async function getChromiumCommits(
+  fromRef: string,
+  toRef: string,
+): Promise<{ log: ChromiumCommit[]; next?: string }> {
+  const url = `${CHROMIUM_GITILES_BASE}/+log/${fromRef}..${toRef}?format=JSON`;
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch Chromium commits: ${response.status}`);
+  }
+  const text = await response.text();
+  return parseGitilesJSON(text);
 }

--- a/src/utils/get-chromium-tags.ts
+++ b/src/utils/get-chromium-tags.ts
@@ -32,34 +32,3 @@ export async function getChromiumReleases({
   const releases = (await response.json()) as Release[];
   return releases.sort((a, b) => a.time - b.time).map((r) => r.version);
 }
-
-export interface ChromiumCommit {
-  commit: string;
-  tree: string;
-  parents: string[];
-  author: {
-    name: string;
-    email: string;
-    time: string;
-  };
-  committer: {
-    name: string;
-    email: string;
-    time: string;
-  };
-  message: string;
-}
-
-export async function getChromiumCommits(
-  fromRef: string,
-  toRef: string,
-): Promise<{ log: ChromiumCommit[]; next?: string }> {
-  const url = `https://chromium.googlesource.com/chromium/src/+log/${fromRef}..${toRef}?format=JSON`;
-  const response = await fetch(url);
-  if (!response.ok) {
-    throw new Error(`Failed to fetch Chromium commits: ${response.status}`);
-  }
-  const text = await response.text();
-  // Gitiles prefixes JSON responses with )]}' for security, so strip it
-  return JSON.parse(text.slice(text.indexOf('{')));
-}

--- a/src/utils/github-utils.ts
+++ b/src/utils/github-utils.ts
@@ -1,0 +1,13 @@
+import type { Octokit as GitHub } from '@octokit/rest';
+
+export async function getContent(
+  github: GitHub,
+  options: Parameters<typeof github.repos.getContent>[0],
+): Promise<{ content: string; sha: string } | null> {
+  const { data } = await github.repos.getContent(options);
+
+  if (!('content' in data)) return null;
+
+  const content = Buffer.from(data.content, 'base64').toString('utf8');
+  return { content, sha: data.sha };
+}

--- a/src/utils/pr-text.ts
+++ b/src/utils/pr-text.ts
@@ -1,4 +1,5 @@
 import { ROLL_TARGETS, RollTarget } from '../constants.js';
+import { CHROMIUM_GITILES_BASE } from './chromium-gitiles.js';
 
 interface PRTextDetails {
   previousVersion: string;
@@ -23,9 +24,7 @@ function getChromiumPRText(details: PRTextDetails) {
   const isMain = !newVersion.includes('.');
   const shortVersion = isMain ? newVersion.substr(11) : newVersion;
   const shortPreviousVersion = isMain ? previousVersion.substr(11) : previousVersion;
-  const diffLink =
-    `https://chromium.googlesource.com/chromium/src/+log/` +
-    `${previousVersion}..${newVersion}?n=10000&pretty=fuller`;
+  const diffLink = `${CHROMIUM_GITILES_BASE}/+log/${previousVersion}..${newVersion}?n=10000&pretty=fuller`;
   return {
     title: `chore: bump ${ROLL_TARGETS.chromium.name} to ${shortVersion} (${branchName})`,
     body: `Updating Chromium to ${shortVersion}${isMain ? ' (main)' : ''}.

--- a/src/utils/roll-build-images.ts
+++ b/src/utils/roll-build-images.ts
@@ -1,6 +1,7 @@
 import debug from 'debug';
 
 import { MAIN_BRANCH, REPOS } from '../constants.js';
+import { CHROMIUM_GITILES_BASE } from './chromium-gitiles.js';
 import { getOctokit } from './octokit.js';
 import { PullsListResponseItem } from '../types.js';
 import { Octokit } from '@octokit/rest';
@@ -47,9 +48,7 @@ export async function rollBuildImages(
 
   const { owner, repo } = REPOS.buildImages;
 
-  const diffLink =
-    `https://chromium.googlesource.com/chromium/src/+log/` +
-    `${previousSha}..${newSha}?n=10000&pretty=fuller`;
+  const diffLink = `${CHROMIUM_GITILES_BASE}/+log/${previousSha}..${newSha}?n=10000&pretty=fuller`;
 
   // Look for a pre-existing PR that targets this branch to see if we can update that.
   let existingPrsForBranch: PullsListResponseItem[] = [];

--- a/src/utils/roll-build-images.ts
+++ b/src/utils/roll-build-images.ts
@@ -2,6 +2,7 @@ import debug from 'debug';
 
 import { MAIN_BRANCH, REPOS } from '../constants.js';
 import { CHROMIUM_GITILES_BASE } from './chromium-gitiles.js';
+import { getContent } from './github-utils.js';
 import { getOctokit } from './octokit.js';
 import { PullsListResponseItem } from '../types.js';
 import { Octokit } from '@octokit/rest';
@@ -11,13 +12,13 @@ export async function getFileContentFromBuildImages(
   filePath: string,
   ref = MAIN_BRANCH,
 ) {
-  const { data } = await octokit.repos.getContent({
+  const data = await getContent(octokit, {
     ...REPOS.buildImages,
     path: filePath,
     ref,
   });
-  if ('content' in data) {
-    return { raw: Buffer.from(data.content, 'base64').toString('utf8'), sha: data.sha };
+  if (data !== null) {
+    return { raw: data.content, sha: data.sha };
   }
   throw new Error(`Failed to get content for ${filePath}`);
 }

--- a/src/utils/update-deps.ts
+++ b/src/utils/update-deps.ts
@@ -1,4 +1,5 @@
 import { REPOS } from '../constants.js';
+import { getContent } from './github-utils.js';
 import { getOctokit } from './octokit.js';
 
 export interface UpdateDepsParams {
@@ -11,27 +12,26 @@ export interface UpdateDepsParams {
 export async function updateDepsFile({ depName, depKey, branch, targetVersion }: UpdateDepsParams) {
   const github = await getOctokit();
 
-  const { data } = await github.repos.getContent({
+  const deps = await getContent(github, {
     ...REPOS.electron,
     path: 'DEPS',
     ref: branch,
   });
 
-  if (!('content' in data)) return;
+  if (deps === null) return;
 
-  const content = Buffer.from(data.content, 'base64').toString('utf8');
   const previousRegex = new RegExp(`${depKey}':\n +'(.+?)',`, 'm');
-  const [, previousDEPSVersion] = previousRegex.exec(content);
+  const [, previousDEPSVersion] = previousRegex.exec(deps.content);
 
   if (targetVersion !== previousDEPSVersion) {
     const regexToReplace = new RegExp(`(${depKey}':\n +').+?',`, 'gm');
-    const newContent = content.replace(regexToReplace, `$1${targetVersion}',`);
+    const newContent = deps.content.replace(regexToReplace, `$1${targetVersion}',`);
     await github.repos.createOrUpdateFileContents({
       ...REPOS.electron,
       path: 'DEPS',
       content: Buffer.from(newContent).toString('base64'),
       message: `chore: bump ${depName} in DEPS to ${targetVersion}`,
-      sha: data.sha,
+      sha: deps.sha,
       branch,
     });
   }

--- a/src/windows-image-handler.ts
+++ b/src/windows-image-handler.ts
@@ -6,6 +6,7 @@ import {
   ARC_RUNNER_ENVIRONMENTS,
   MAIN_BRANCH,
 } from './constants.js';
+import { getContent } from './utils/github-utils.js';
 import { getOctokit } from './utils/octokit.js';
 import { currentWindowsImage, didFileChangeBetweenShas } from './utils/arc-image.js';
 import { rollInfra } from './utils/roll-infra.js';
@@ -56,14 +57,13 @@ export async function rollWindowsArcImage() {
   for (const arcEnv of Object.keys(ARC_RUNNER_ENVIRONMENTS)) {
     d(`Fetching current version of "${arcEnv}" arc image in: ${ARC_RUNNER_ENVIRONMENTS[arcEnv]}`);
 
-    const currentVersion = await octokit.repos.getContent({
+    const data = await getContent(octokit, {
       owner: REPOS.electronInfra.owner,
       repo: REPOS.electronInfra.repo,
       path: ARC_RUNNER_ENVIRONMENTS[arcEnv],
     });
-    const data = currentVersion.data;
-    if ('content' in data) {
-      const currentContent = Buffer.from(data.content, 'base64').toString('utf8');
+    if (data !== null) {
+      const currentContent = data.content;
       const currentImage = currentWindowsImage(currentContent);
 
       if (currentImage !== latestWindowsImage) {

--- a/tests/build-images.test.ts
+++ b/tests/build-images.test.ts
@@ -1,6 +1,7 @@
 import handler from '../src/index.js';
 import { beforeEach, afterEach, describe, it, vi, expect } from 'vitest';
 import * as buildImagesHandler from '../src/build-images-handler.js';
+import { getContent } from '../src/utils/github-utils.js';
 import { getOctokit } from '../src/utils/octokit.js';
 
 import { Probot, ProbotOctokit } from 'probot';
@@ -14,6 +15,7 @@ const INSTALLATION_ID = 123456;
 const payloadJson = await import('./fixtures/publish_payload.json');
 const branchName = `roller/build-images/${MAIN_BRANCH}`;
 
+vi.mock('../src/utils/github-utils.js');
 vi.mock('../src/utils/octokit.js');
 
 describe('build-images', () => {
@@ -204,20 +206,16 @@ describe('build-images', () => {
 
   describe('updateFilesWithNewOid', () => {
     it('updates files that contain the previous OID', async () => {
-      mockOctokit.rest.repos.getContent.mockImplementation(({ path }) => {
-        if (path === '.github/workflows/linux-publish.yml') {
+      vi.mocked(getContent).mockImplementation(async (_, options) => {
+        if (options?.path === '.github/workflows/linux-publish.yml') {
           return {
-            data: {
-              content: Buffer.from('image: ghcr.io/electron/build:oldsha123').toString('base64'),
-              sha: 'linux-publishsha',
-            },
+            content: 'image: ghcr.io/electron/build:oldsha123',
+            sha: 'linux-publishsha',
           };
         } else {
           return {
-            data: {
-              content: Buffer.from('no matches here').toString('base64'),
-              sha: 'file2sha',
-            },
+            content: 'no matches here',
+            sha: 'file2sha',
           };
         }
       });
@@ -232,7 +230,7 @@ describe('build-images', () => {
       );
 
       expect(result).toBe(true);
-      expect(mockOctokit.rest.repos.getContent).toHaveBeenCalledTimes(7);
+      expect(getContent).toHaveBeenCalledTimes(7);
       expect(mockOctokit.rest.repos.createOrUpdateFileContents).toHaveBeenCalledTimes(1);
       expect(mockOctokit.rest.repos.createOrUpdateFileContents).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -245,11 +243,9 @@ describe('build-images', () => {
     });
 
     it('returns false when no files need updating', async () => {
-      mockOctokit.rest.repos.getContent.mockResolvedValue({
-        data: {
-          content: Buffer.from('no matches here').toString('base64'),
-          sha: 'filesha',
-        },
+      vi.mocked(getContent).mockResolvedValue({
+        content: 'no matches here',
+        sha: 'filesha',
       });
 
       const result = await buildImagesHandler.updateFilesWithNewOid(
@@ -273,15 +269,9 @@ describe('build-images', () => {
 
       mockOctokit.rest.pulls.list.mockResolvedValue({ data: [] });
 
-      mockOctokit.rest.repos.getContent.mockImplementation(() => {
-        return {
-          data: {
-            content: Buffer.from(
-              'image: ghcr.io/electron/build:424eedbf277ad9749ffa9219068aa72ed4a5e373',
-            ).toString('base64'),
-            sha: 'linux-publishsha',
-          },
-        };
+      vi.mocked(getContent).mockResolvedValue({
+        content: 'image: ghcr.io/electron/build:424eedbf277ad9749ffa9219068aa72ed4a5e373',
+        sha: 'linux-publishsha',
       });
 
       const payload = JSON.parse(JSON.stringify(payloadJson));
@@ -312,9 +302,7 @@ describe('build-images', () => {
       const newSha = randomBytes(20).toString('hex');
 
       mockOctokit.rest.pulls.list.mockResolvedValue({ data: [] });
-      mockOctokit.rest.repos.getContent.mockResolvedValue({
-        data: { content: Buffer.from(newSha).toString('base64') },
-      });
+      vi.mocked(getContent).mockResolvedValue({ content: newSha, sha: 'foo' });
 
       vi.spyOn(buildImagesHandler, 'getPreviousOid').mockResolvedValue('oldsha123');
 

--- a/tests/handlers.spec.ts
+++ b/tests/handlers.spec.ts
@@ -5,11 +5,13 @@ import { getSupportedBranches } from '../src/utils/get-supported-branches.js';
 import { handleNodeCheck } from '../src/node-handler.js';
 import { handleChromiumCheck } from '../src/chromium-handler.js';
 import { getChromiumReleases } from '../src/utils/get-chromium-tags.js';
+import { getContent } from '../src/utils/github-utils.js';
 import { getOctokit } from '../src/utils/octokit.js';
 import { roll } from '../src/utils/roll.js';
 import { getLatestLTSVersion } from '../src/utils/get-nodejs-lts.js';
 
 vi.mock('../src/utils/get-chromium-tags.js');
+vi.mock('../src/utils/github-utils.js');
 vi.mock('../src/utils/octokit.js');
 vi.mock('../src/utils/roll.js');
 vi.mock('../src/utils/get-nodejs-lts.js');
@@ -52,11 +54,9 @@ describe('handleChromiumCheck()', () => {
         },
       ]);
 
-      mockOctokit.repos.getContent.mockReturnValue({
-        data: {
-          content: Buffer.from(`${ROLL_TARGETS.chromium.depsKey}':\n    '1.0.0.0',`),
-          sha: '1234',
-        },
+      vi.mocked(getContent).mockResolvedValue({
+        content: `${ROLL_TARGETS.chromium.depsKey}':\n    '1.0.0.0',`,
+        sha: '1234',
       });
     });
 
@@ -156,11 +156,9 @@ describe('handleChromiumCheck()', () => {
     it('takes no action if no new minor/build/patch available', async () => {
       vi.mocked(getChromiumReleases).mockResolvedValue([]);
 
-      mockOctokit.repos.getContent.mockReturnValue({
-        data: {
-          content: Buffer.from(`${ROLL_TARGETS.chromium.depsKey}':\n    '1.5.0.0',`),
-          sha: '1234',
-        },
+      vi.mocked(getContent).mockResolvedValue({
+        content: `${ROLL_TARGETS.chromium.depsKey}':\n    '1.5.0.0',`,
+        sha: '1234',
       });
 
       await handleChromiumCheck();
@@ -169,11 +167,9 @@ describe('handleChromiumCheck()', () => {
     });
 
     it('fails if DEPS version invalid', async () => {
-      mockOctokit.repos.getContent.mockReturnValue({
-        data: {
-          content: Buffer.from(`${ROLL_TARGETS.chromium.depsKey}':\n    'someCommitSha',`),
-          sha: '1234',
-        },
+      vi.mocked(getContent).mockResolvedValue({
+        content: `${ROLL_TARGETS.chromium.depsKey}':\n    'someCommitSha',`,
+        sha: '1234',
       });
 
       expect.assertions(2);
@@ -198,11 +194,9 @@ describe('handleChromiumCheck()', () => {
         },
       ]);
 
-      mockOctokit.repos.getContent.mockReturnValue({
-        data: {
-          content: Buffer.from(`${ROLL_TARGETS.chromium.depsKey}':\n    '1.1.0.0',`),
-          sha: '1234',
-        },
+      vi.mocked(getContent).mockResolvedValue({
+        content: `${ROLL_TARGETS.chromium.depsKey}':\n    '1.1.0.0',`,
+        sha: '1234',
       });
     });
 
@@ -238,11 +232,9 @@ describe('handleChromiumCheck()', () => {
       },
     ]);
 
-    mockOctokit.repos.getContent.mockReturnValue({
-      data: {
-        content: Buffer.from(`${ROLL_TARGETS.chromium.depsKey}':\n    '1.0.0.0',`),
-        sha: '1234',
-      },
+    vi.mocked(getContent).mockResolvedValue({
+      content: `${ROLL_TARGETS.chromium.depsKey}':\n    '1.0.0.0',`,
+      sha: '1234',
     });
     vi.mocked(getChromiumReleases).mockResolvedValue(['1.1.0.0', '1.2.0.0', '2.1.0.0']);
 
@@ -322,11 +314,9 @@ describe('handleNodeCheck()', () => {
       },
     ]);
 
-    mockOctokit.repos.getContent.mockReturnValue({
-      data: {
-        content: Buffer.from(`${ROLL_TARGETS.node.depsKey}':\n    'v12.0.0',`),
-        sha: '1234',
-      },
+    vi.mocked(getContent).mockResolvedValue({
+      content: `${ROLL_TARGETS.node.depsKey}':\n    'v12.0.0',`,
+      sha: '1234',
     });
 
     await handleNodeCheck();
@@ -346,11 +336,9 @@ describe('handleNodeCheck()', () => {
   it('does not roll for uneven major versions of Node.js', async () => {
     vi.mocked(getLatestLTSVersion).mockResolvedValue('12.0.0');
 
-    mockOctokit.repos.getContent.mockReturnValue({
-      data: {
-        content: Buffer.from(`${ROLL_TARGETS.node.depsKey}':\n    'v11.0.0',`),
-        sha: '1234',
-      },
+    vi.mocked(getContent).mockResolvedValue({
+      content: `${ROLL_TARGETS.node.depsKey}':\n    'v11.0.0',`,
+      sha: '1234',
     });
     await handleNodeCheck();
 
@@ -360,11 +348,9 @@ describe('handleNodeCheck()', () => {
   it('does not roll if no newer release found', async () => {
     vi.mocked(getLatestLTSVersion).mockResolvedValue('12.0.0');
 
-    mockOctokit.repos.getContent.mockReturnValue({
-      data: {
-        content: Buffer.from(`${ROLL_TARGETS.node.depsKey}':\n    'v12.2.0',`),
-        sha: '1234',
-      },
+    vi.mocked(getContent).mockResolvedValue({
+      content: `${ROLL_TARGETS.node.depsKey}':\n    'v12.2.0',`,
+      sha: '1234',
     });
     await handleNodeCheck();
 
@@ -374,11 +360,9 @@ describe('handleNodeCheck()', () => {
   it('throws error if roll() process failed', async () => {
     vi.mocked(getLatestLTSVersion).mockResolvedValue('14.0.0');
 
-    mockOctokit.repos.getContent.mockReturnValue({
-      data: {
-        content: Buffer.from(`${ROLL_TARGETS.node.depsKey}':\n    'v12.0.0',`),
-        sha: '1234',
-      },
+    vi.mocked(getContent).mockResolvedValue({
+      content: `${ROLL_TARGETS.node.depsKey}':\n    'v12.0.0',`,
+      sha: '1234',
     });
 
     vi.mocked(roll)

--- a/tests/utils/chromium-gitiles.test.ts
+++ b/tests/utils/chromium-gitiles.test.ts
@@ -5,9 +5,10 @@ import {
   getChromiumHeadSha,
   getChromiumFileContent,
   didChromiumFilesChange,
+  CHROMIUM_GITILES_BASE,
 } from '../../src/utils/chromium-gitiles.js';
 
-const GITILES_BASE = 'https://chromium.googlesource.com';
+const { origin: GITILES_BASE } = new URL(CHROMIUM_GITILES_BASE);
 
 describe('chromium-gitiles', () => {
   beforeEach(() => {

--- a/tests/utils/pr-text.spec.ts
+++ b/tests/utils/pr-text.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { getPRText } from '../../src/utils/pr-text.js';
 import { ROLL_TARGETS, RollTarget } from '../../src/constants.js';
+import { CHROMIUM_GITILES_BASE } from '../../src/utils/chromium-gitiles.js';
 
 vi.mock('../../src/utils/octokit.js');
 
@@ -51,7 +52,7 @@ describe('getPRText()', () => {
       expect(prText.body).toContain(`Original-Version: ${details.previousVersion}`);
       // Contains link to Chromium diff.
       expect(prText.body).toContain(
-        `https://chromium.googlesource.com/chromium/src/+log/${details.previousVersion}..${details.newVersion}?n=10000&pretty=fuller`,
+        `${CHROMIUM_GITILES_BASE}/+log/${details.previousVersion}..${details.newVersion}?n=10000&pretty=fuller`,
       );
     });
 

--- a/tests/utils/update-deps.spec.ts
+++ b/tests/utils/update-deps.spec.ts
@@ -1,9 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { updateDepsFile, UpdateDepsParams } from '../../src/utils/update-deps.js';
+import { getContent } from '../../src/utils/github-utils.js';
 import { getOctokit } from '../../src/utils/octokit.js';
 import { REPOS } from '../../src/constants.js';
 
+vi.mock('../../src/utils/github-utils.js');
 vi.mock('../../src/utils/octokit.js');
 
 describe('updateDepsFile()', () => {
@@ -13,12 +15,6 @@ describe('updateDepsFile()', () => {
   beforeEach(() => {
     mockOctokit = {
       repos: {
-        getContent: vi.fn().mockImplementation(() => ({
-          data: {
-            content: Buffer.from("'testKey':\n    'v4.0.0',"),
-            sha: '1234',
-          },
-        })),
         createOrUpdateFileContents: vi.fn(),
       },
     };
@@ -29,6 +25,10 @@ describe('updateDepsFile()', () => {
       branch: 'testBranch',
       targetVersion: 'v10.0.0',
     } as UpdateDepsParams;
+    vi.mocked(getContent).mockResolvedValue({
+      content: "'testKey':\n    'v4.0.0',",
+      sha: '1234',
+    });
   });
 
   it('returns the previous and new version numbers', async () => {


### PR DESCRIPTION
Was looking to add some new functionality here and noticed a good amount of repetitive common code so cleaning that up before adding new code that will use these same helpers.