### PR TITLE
fix: validate OIDs and use literal file rewrites in build-images handler

### DIFF
--- a/src/build-images-handler.ts
+++ b/src/build-images-handler.ts
@@ -17,6 +17,16 @@ const files = [
   '.devcontainer/docker-compose.yml',
 ];
 
+// Git object IDs are 40-character lowercase hex strings. Any value taken from a
+// webhook payload or package metadata must match this exactly before it is used
+// to match against or rewrite file content, so that attacker-controlled tags
+// cannot be interpreted as regular expressions or replacement patterns.
+const OID_REGEX = /^[0-9a-f]{40}$/;
+
+export function isValidOid(value: unknown): value is string {
+  return typeof value === 'string' && OID_REGEX.test(value);
+}
+
 export async function shouldUpdateFiles(octokit: Octokit, oid: string) {
   const file = await getContent(octokit, {
     ...REPOS.electron,
@@ -27,8 +37,9 @@ export async function shouldUpdateFiles(octokit: Octokit, oid: string) {
     throw new Error(`Could not fetch content for ${files[0]}`);
   }
 
-  const match = file.content.match(oid);
-  if (match?.[0] === oid) {
+  // `oid` is a validated 40-char hex OID; use a literal substring check so the
+  // value is never compiled into a regular expression.
+  if (file.content.includes(oid)) {
     return false;
   }
 
@@ -54,7 +65,15 @@ export async function getPreviousOid(payload: Context<'registry_package.publishe
       return metadata.container.tags[0] !== target_oid;
     });
 
-    return previousPackage.metadata.container.tags[0] || null;
+    const previousTag = previousPackage?.metadata.container.tags[0];
+
+    // The tag is attacker-influenceable package metadata. Only accept it if it
+    // is a well-formed OID; otherwise it must not be used to match/rewrite files.
+    if (!isValidOid(previousTag)) {
+      return null;
+    }
+
+    return previousTag;
   } catch (error) {
     console.error('Error fetching previous target_oid:', error);
     return null;
@@ -70,6 +89,13 @@ export async function updateFilesWithNewOid(
   const d = debug(`roller/github:updateFilesWithNewOid`);
   let updatedAny = false;
 
+  // Defense-in-depth: never match against or substitute values that are not
+  // well-formed OIDs, regardless of how this function is reached.
+  if (!isValidOid(previousOid) || !isValidOid(targetOid)) {
+    d(`Refusing to update files with invalid OID(s)`);
+    return updatedAny;
+  }
+
   for (const filePath of files) {
     try {
       const file = await getContent(octokit, {
@@ -81,14 +107,16 @@ export async function updateFilesWithNewOid(
         throw new Error(`Could not fetch content for ${filePath}`);
       }
 
-      const match = file.content.match(previousOid);
-      if (!match) {
+      // `previousOid` and `targetOid` are validated 40-char hex OIDs. Use literal
+      // substring matching and split/join so neither value is ever interpreted as
+      // a regular expression or as a replacement pattern (e.g. `$&`, `$1`).
+      if (!file.content.includes(previousOid)) {
         d(`No match found for ${filePath}`);
         continue;
       }
 
-      d(`Updating ${filePath} from ${match[0]} to ${targetOid}`);
-      const newContent = file.content.replace(match[0], targetOid);
+      d(`Updating ${filePath} from ${previousOid} to ${targetOid}`);
+      const newContent = file.content.split(previousOid).join(targetOid);
       await octokit.rest.repos.createOrUpdateFileContents({
         ...REPOS.electron,
         path: filePath,
@@ -141,6 +169,14 @@ export async function handleBuildImagesCheck(
   const octokit = await getOctokit();
 
   const { target_oid: targetOid } = payload.registry_package.package_version;
+
+  // `target_oid` comes straight from the webhook payload and is written into
+  // workflow file content. Refuse to proceed unless it is a well-formed OID.
+  if (!isValidOid(targetOid)) {
+    d(`Invalid target OID in payload, cannot proceed with updates`);
+    return;
+  }
+
   const previousOid = await getPreviousOid(payload);
 
   if (!previousOid) {

--- a/tests/build-images.test.ts
+++ b/tests/build-images.test.ts
@@ -206,10 +206,13 @@ describe('build-images', () => {
 
   describe('updateFilesWithNewOid', () => {
     it('updates files that contain the previous OID', async () => {
+      const previousOid = '424eedbf277ad9749ffa9219068aa72ed4a5e373';
+      const targetOid = 'bed562b00714c63080bda07af3f016cab4ba02fc';
+
       vi.mocked(getContent).mockImplementation(async (_, options) => {
         if (options?.path === '.github/workflows/linux-publish.yml') {
           return {
-            content: 'image: ghcr.io/electron/build:oldsha123',
+            content: `image: ghcr.io/electron/build:${previousOid}`,
             sha: 'linux-publishsha',
           };
         } else {
@@ -224,8 +227,8 @@ describe('build-images', () => {
 
       const result = await buildImagesHandler.updateFilesWithNewOid(
         mockOctokit,
-        'oldsha123',
-        'newsha456',
+        previousOid,
+        targetOid,
         branchName,
       );
 
@@ -250,12 +253,32 @@ describe('build-images', () => {
 
       const result = await buildImagesHandler.updateFilesWithNewOid(
         mockOctokit,
-        'oldsha123',
-        'newsha456',
+        '424eedbf277ad9749ffa9219068aa72ed4a5e373',
+        'bed562b00714c63080bda07af3f016cab4ba02fc',
         branchName,
       );
 
       expect(result).toBe(false);
+      expect(mockOctokit.rest.repos.createOrUpdateFileContents).not.toHaveBeenCalled();
+    });
+
+    it('refuses to update files when given OIDs that are not valid hex object IDs', async () => {
+      vi.mocked(getContent).mockResolvedValue({
+        content: 'jobs:\n  build:\n    runs-on: ubuntu-latest\n',
+        sha: 'filesha',
+      });
+
+      // A crafted container tag containing regex metacharacters must never be
+      // compiled into a regular expression or matched against file content.
+      const result = await buildImagesHandler.updateFilesWithNewOid(
+        mockOctokit,
+        'jobs[\\s\\S]*',
+        'malicious replacement',
+        branchName,
+      );
+
+      expect(result).toBe(false);
+      expect(getContent).not.toHaveBeenCalled();
       expect(mockOctokit.rest.repos.createOrUpdateFileContents).not.toHaveBeenCalled();
     });
   });


### PR DESCRIPTION
Package metadata and webhook payload values (target_oid, the first container tag of a prior package version) were used as a regular expression and as replacement text when rewriting electron/electron workflow files. String.prototype.match compiles its string argument into a RegExp, so a crafted container tag containing regex metacharacters could match an arbitrary region of a workflow file, and the target_oid was written into the result verbatim — allowing whoever can publish package versions in electron/build-images to inject unreviewed, attacker-shaped edits into CI workflow content.

Validate every OID taken from a webhook payload or package metadata against a strict 40-character hex format before use, and replace the regex-based match/replace with literal substring matching and split/join so neither value is ever interpreted as a regular expression or a replacement pattern.
