### PR TITLE
fix: derive roll write target from trusted state, not untrusted PRs

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -19,6 +19,10 @@ export const REPOS = {
 
 export const REPO_OWNER = 'electron';
 
+// Login of the GitHub App that opens and maintains roll PRs. The bot only ever
+// updates roll PRs it authored itself.
+export const ROLLER_BOT_LOGIN = 'electron-roller[bot]';
+
 export const MAIN_BRANCH = 'main';
 
 export const CHROMIUM_UPGRADE_WORKFLOW = {

--- a/src/utils/roll.ts
+++ b/src/utils/roll.ts
@@ -8,6 +8,7 @@ import {
   NO_BACKPORT,
   REPOS,
   ROLL_TARGETS,
+  ROLLER_BOT_LOGIN,
   RollTarget,
 } from '../constants.js';
 import { ReposListBranchesResponseItem, PullsListResponseItem } from '../types.js';
@@ -100,19 +101,22 @@ export async function roll({
 
     // Update existing PR(s)
     for (const pr of prs) {
-      if (pr.user.login.startsWith('trop')) continue;
-
-      // Only act on the bot's own roll PR. Its head must live in the
-      // electron/electron repo itself (not a fork) and be named exactly as the
-      // bot names its roll branches. Any open PR can match the title prefix - a
-      // fork PR's head ref/title/body are entirely attacker-controlled - so they
-      // must never be allowed to select the branch a privileged commit lands on
-      // or to receive bot-applied label/title updates.
-      if (pr.head.repo?.full_name !== electronRepoFullName || pr.head.ref !== rollBranchName) {
+      // Only act on the bot's own roll PR. It must be authored by the roller
+      // bot, its head must live in the electron/electron repo itself (not a
+      // fork), and it must be named exactly as the bot names its roll branches.
+      // Any open PR can match the title prefix - a fork PR's author, head ref,
+      // title and body are all attacker-controlled - so none of them may be
+      // allowed to select the branch a privileged commit lands on or to receive
+      // bot-applied label/title updates.
+      if (
+        pr.user.login !== ROLLER_BOT_LOGIN ||
+        pr.head.repo?.full_name !== electronRepoFullName ||
+        pr.head.ref !== rollBranchName
+      ) {
         d(
-          `Ignoring PR #${pr.number} - head ${pr.head.repo?.full_name ?? '<unknown>'}:${
-            pr.head.ref
-          } is not the bot's roll branch ${electronRepoFullName}:${rollBranchName}`,
+          `Ignoring PR #${pr.number} (@${pr.user.login}, head ${
+            pr.head.repo?.full_name ?? '<unknown>'
+          }:${pr.head.ref}) - not the bot's roll branch ${electronRepoFullName}:${rollBranchName}`,
         );
         continue;
       }

--- a/src/utils/roll.ts
+++ b/src/utils/roll.ts
@@ -91,9 +91,32 @@ export async function roll({
   );
 
   if (prs.length) {
+    // The bot only ever rolls into the branch it created itself, which it names
+    // `roller/<target>/<electron branch>` in the electron/electron repo. Derive
+    // the write target solely from this trusted naming rather than from any
+    // field of the (potentially untrusted) PR.
+    const rollBranchName = `roller/${rollTarget.name}/${electronBranch.name}`;
+    const electronRepoFullName = `${REPOS.electron.owner}/${REPOS.electron.repo}`;
+
     // Update existing PR(s)
     for (const pr of prs) {
       if (pr.user.login.startsWith('trop')) continue;
+
+      // Only act on the bot's own roll PR. Its head must live in the
+      // electron/electron repo itself (not a fork) and be named exactly as the
+      // bot names its roll branches. Any open PR can match the title prefix - a
+      // fork PR's head ref/title/body are entirely attacker-controlled - so they
+      // must never be allowed to select the branch a privileged commit lands on
+      // or to receive bot-applied label/title updates.
+      if (pr.head.repo?.full_name !== electronRepoFullName || pr.head.ref !== rollBranchName) {
+        d(
+          `Ignoring PR #${pr.number} - head ${pr.head.repo?.full_name ?? '<unknown>'}:${
+            pr.head.ref
+          } is not the bot's roll branch ${electronRepoFullName}:${rollBranchName}`,
+        );
+        continue;
+      }
+
       d(`Found existing PR: #${pr.number} opened by ${pr.user.login}`);
 
       // Check to see if automatic DEPS roll has been temporarily disabled
@@ -107,7 +130,7 @@ export async function roll({
       const { previousDEPSVersion, newDEPSVersion } = await updateDepsFile({
         depName: rollTarget.name,
         depKey: rollTarget.depsKey,
-        branch: pr.head.ref,
+        branch: rollBranchName,
         targetVersion,
       });
 

--- a/tests/utils/roll.spec.ts
+++ b/tests/utils/roll.spec.ts
@@ -225,6 +225,36 @@ describe('roll()', () => {
     expect(mockOctokit.pulls.update).not.toHaveBeenCalled();
   });
 
+  it('ignores a same-repo roll-branch PR not authored by the roller bot', async () => {
+    // Even when the head repo and ref match the bot's roll branch exactly, a PR
+    // opened by anyone other than the roller bot must not be touched.
+    mockOctokit.paginate.mockReturnValue([
+      {
+        user: {
+          login: 'someone-else',
+        },
+        title: `chore: bump ${ROLL_TARGETS.node.name} to bar`,
+        number: 1,
+        head: {
+          ref: `roller/${ROLL_TARGETS.node.name}/${branch.name}`,
+          repo: { full_name: `${REPOS.electron.owner}/${REPOS.electron.repo}` },
+        },
+        body: 'Original-Version: v4.0.0',
+        labels: [],
+        created_at: new Date().toISOString(),
+      },
+    ]);
+
+    await roll({
+      rollTarget: ROLL_TARGETS.node,
+      electronBranch: branch,
+      targetVersion: 'v10.0.0',
+    });
+
+    expect(updateDepsFile).not.toHaveBeenCalled();
+    expect(mockOctokit.pulls.update).not.toHaveBeenCalled();
+  });
+
   it('creates a new PR if none found', async () => {
     mockOctokit.paginate.mockReturnValue([]);
 

--- a/tests/utils/roll.spec.ts
+++ b/tests/utils/roll.spec.ts
@@ -69,7 +69,8 @@ describe('roll()', () => {
         title: `chore: bump ${ROLL_TARGETS.node.name} to foo`,
         number: 1,
         head: {
-          ref: 'asd',
+          ref: `roller/${ROLL_TARGETS.node.name}/${branch.name}`,
+          repo: { full_name: `${REPOS.electron.owner}/${REPOS.electron.repo}` },
         },
         body: 'Original-Version: v4.0.0',
         labels: [{ name: 'hello' }, { name: 'goodbye' }],
@@ -133,7 +134,8 @@ describe('roll()', () => {
         title: `chore: bump ${ROLL_TARGETS.node.name} to bar`,
         number: 1,
         head: {
-          ref: 'asd',
+          ref: `roller/${ROLL_TARGETS.node.name}/${branch.name}`,
+          repo: { full_name: `${REPOS.electron.owner}/${REPOS.electron.repo}` },
         },
         body: 'Original-Version: v4.0.0',
         labels: [{ name: 'hello' }, { name: 'goodbye' }],
@@ -157,6 +159,70 @@ describe('roll()', () => {
         body: expect.stringContaining('Original-Version: v4.0.0'),
       }),
     );
+  });
+
+  it('ignores a PR whose head is a fork branch impersonating the roll branch', async () => {
+    // An attacker forks electron/electron and names their branch after the
+    // bot's roll branch, opening a PR with a matching title. The bot must not
+    // read from or commit to that attacker-controlled ref, nor update its
+    // title/body/labels.
+    mockOctokit.paginate.mockReturnValue([
+      {
+        user: {
+          login: 'attacker',
+        },
+        title: `chore: bump ${ROLL_TARGETS.node.name} to evil`,
+        number: 1,
+        head: {
+          ref: `roller/${ROLL_TARGETS.node.name}/${branch.name}`,
+          repo: { full_name: 'attacker/electron' },
+        },
+        body: 'Original-Version: v4.0.0',
+        labels: [],
+        created_at: new Date().toISOString(),
+      },
+    ]);
+
+    await roll({
+      rollTarget: ROLL_TARGETS.node,
+      electronBranch: branch,
+      targetVersion: 'v10.0.0',
+    });
+
+    expect(updateDepsFile).not.toHaveBeenCalled();
+    expect(mockOctokit.pulls.update).not.toHaveBeenCalled();
+    expect(mockOctokit.issues.addLabels).not.toHaveBeenCalled();
+  });
+
+  it('ignores a same-repo PR whose head ref is not the roll branch', async () => {
+    // A same-repo PR matching the title prefix but not on the bot's roll branch
+    // must not be touched either - the write target is derived from trusted
+    // naming, never from the PR.
+    mockOctokit.paginate.mockReturnValue([
+      {
+        user: {
+          login: 'maintainer',
+        },
+        title: `chore: bump ${ROLL_TARGETS.node.name} to manual`,
+        number: 1,
+        head: {
+          ref: 'some-manual-branch',
+          repo: { full_name: `${REPOS.electron.owner}/${REPOS.electron.repo}` },
+        },
+        body: 'Original-Version: v4.0.0',
+        labels: [],
+        created_at: new Date().toISOString(),
+      },
+    ]);
+
+    await roll({
+      rollTarget: ROLL_TARGETS.node,
+      electronBranch: branch,
+      targetVersion: 'v10.0.0',
+    });
+
+    expect(updateDepsFile).not.toHaveBeenCalled();
+    expect(mockOctokit.pulls.update).not.toHaveBeenCalled();
   });
 
   it('creates a new PR if none found', async () => {
@@ -209,7 +275,10 @@ describe('roll()', () => {
           user: { login: 'electron-roller[bot]' },
           title: `chore: bump ${ROLL_TARGETS.chromium.name} to bar`,
           number: 1,
-          head: { ref: 'asd' },
+          head: {
+            ref: `roller/${ROLL_TARGETS.chromium.name}/${mainBranch.name}`,
+            repo: { full_name: `${REPOS.electron.owner}/${REPOS.electron.repo}` },
+          },
           body: 'Original-Version: 119.0.0.0',
           labels: [],
           created_at: new Date().toISOString(),
@@ -277,7 +346,8 @@ describe('roll()', () => {
         title: ROLL_TARGETS.node.name,
         number: 1,
         head: {
-          ref: 'asd',
+          ref: `roller/${ROLL_TARGETS.node.name}/${branch.name}`,
+          repo: { full_name: `${REPOS.electron.owner}/${REPOS.electron.repo}` },
         },
         body: 'Original-Version: v4.0.0',
         labels: [{ name: 'roller/pause' }],


### PR DESCRIPTION
During a roll, the bot listed all open PRs whose base is the branch being rolled and whose title starts with "chore: bump node"/"chore: bump chromium", then called updateDepsFile with branch = pr.head.ref. Any GitHub user can open such a PR from a fork, where head.ref is just the fork's branch name. By naming a fork branch after one of the bot's own roll branches (e.g. roller/chromium/35-x-y), an attacker could steer the privileged GitHub App into reading from and committing a DEPS change onto that branch, and have their PR's title/body/labels rewritten by the bot.

The branch the bot reads from and commits to is now derived solely from trusted state it created itself (roller/<target>/<electron branch>). Each candidate PR must originate from a branch in the electron/electron repo (not a fork) and be named exactly as the bot names its roll branches before any privileged write, pulls.update, or updateLabels call runs. Attacker-controlled fields (head ref, title, body) can no longer select the write target or receive bot mutations.
